### PR TITLE
Fixed copy-and-paste error in Line type

### DIFF
--- a/asyncpg/types.py
+++ b/asyncpg/types.py
@@ -322,7 +322,7 @@ class Line(tuple):
 
     @property
     def C(self):
-        return self[1]
+        return self[2]
 
 
 class LineSegment(tuple):


### PR DESCRIPTION
I was reading the code and I'm pretty sure this is an error.
However, be warned: this change has not been tested.