### PR TITLE
Fix parsing server version string for non-final releases (devel, beta etc.)

### DIFF
--- a/asyncpg/serverversion.py
+++ b/asyncpg/serverversion.py
@@ -16,14 +16,23 @@ def split_server_version_string(version_string):
     parts = version_string.strip().split('.')
     if not parts[-1].isdigit():
         # release level specified
-        level = parts[-1].rstrip('0123456789').lower()
-        serial = parts[-1][level:]
-        versions = [int(p) for p in parts[:-1]][:3]
+        lastitem = parts[-1]
+        levelpart = lastitem.rstrip('0123456789').lower()
+        if levelpart != lastitem:
+            serial = int(lastitem[len(levelpart):])
+        else:
+            serial = 0
+
+        level = levelpart.lstrip('0123456789')
+        if level != levelpart:
+            parts[-1] = levelpart[:-len(level)]
+        else:
+            parts[-1] = 0
     else:
         level = 'final'
         serial = 0
-        versions = [int(p) for p in parts][:3]
 
+    versions = [int(p) for p in parts][:3]
     if len(versions) < 3:
         versions += [0] * (3 - len(versions))
 


### PR DESCRIPTION
It seems broken from the beginning:
d4a66cbd948c45d8ff43f5a383a7ce9b189f08b8

Detect numbers by both sides of a string in the last part
(they are not split[1] by '.').
Also update parsing version string for Postgres ver>=10 (no minor part[2][3]).

[1] 9.4beta2
https://git.postgresql.org/pg/commitdiff/c85374626f680902c207285b986ac38a134535eb

[2] 10devel
https://git.postgresql.org/pg/commitdiff/ca9112a424ff68ec4f2ef67b47122f7d61412964

[3] new numbering scheme:
discussion:
https://www.postgresql.org/message-id/flat/7684.1470066581%40sss.pgh.pa.us

example:
https://git.postgresql.org/pg/commitdiff/69dc5ae408f68c302029a6b43912a2cc16b1256c