### PR TITLE
More enum tests

### DIFF
--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1066,6 +1066,8 @@ class TestCodecs(tb.ConnectedTestCase):
         try:
             await self.con.execute('INSERT INTO tab (a) VALUES ($1);', "foo")
             await self.con.execute('INSERT INTO tab (a, b) VALUES ($1, $2);', "foo", "abc")
+            await self.con.execute('SELECT a FROM tab;")
+            await self.con.execute('SELECT a, b FROM tab;")
 
         finally:
             await self.con.execute('''

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1066,8 +1066,8 @@ class TestCodecs(tb.ConnectedTestCase):
         try:
             await self.con.execute('INSERT INTO tab (a) VALUES ($1);', "foo")
             await self.con.execute('INSERT INTO tab (a, b) VALUES ($1, $2);', "foo", "abc")
-            await self.con.execute('SELECT a FROM tab;")
-            await self.con.execute('SELECT a, b FROM tab;")
+            await self.con.execute("SELECT a FROM tab;")
+            await self.con.execute("SELECT a, b FROM tab;")
 
         finally:
             await self.con.execute('''

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1064,12 +1064,8 @@ class TestCodecs(tb.ConnectedTestCase):
         ''')
 
         try:
-            await self.con.execute('''
-                INSERT INTO tab (a) VALUES ('foo',);
-            ''')
-            await self.con.execute('''
-                INSERT INTO tab (a, b) VALUES ('foo', 'abc');
-            ''')
+            await self.con.execute('INSERT INTO tab (a) VALUES ($1);', ["foo"])
+            await self.con.execute('INSERT INTO tab (a, b) VALUES ($1, $2);', ["foo", "abc"])
 
         finally:
             await self.con.execute('''

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1064,8 +1064,8 @@ class TestCodecs(tb.ConnectedTestCase):
         ''')
 
         try:
-            await self.con.execute('INSERT INTO tab (a) VALUES ($1);', ["foo"])
-            await self.con.execute('INSERT INTO tab (a, b) VALUES ($1, $2);', ["foo", "abc"])
+            await self.con.execute('INSERT INTO tab (a) VALUES ($1);', "foo")
+            await self.con.execute('INSERT INTO tab (a, b) VALUES ($1, $2);', "foo", "abc")
 
         finally:
             await self.con.execute('''

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1053,3 +1053,26 @@ class TestCodecs(tb.ConnectedTestCase):
                 DROP TABLE tab;
                 DROP TYPE enum_t;
             ''')
+            
+    async def test_enum_2(self):
+        await self.con.execute('''
+            CREATE TYPE enum_t AS ENUM ('abc', 'def', 'ghi');
+            CREATE TABLE tab (
+                a text,
+                b enum_t
+            );
+        ''')
+
+        try:
+            await self.con.execute('''
+                INSERT INTO tab (a) VALUES ('foo',);
+            ''')
+            await self.con.execute('''
+                INSERT INTO tab (a, b) VALUES ('foo', 'abc');
+            ''')
+
+        finally:
+            await self.con.execute('''
+                DROP TABLE tab;
+                DROP TYPE enum_t;
+            ''')


### PR DESCRIPTION
Extra test to cover two separate insert executes, one not using an enum, another one using an enum.

In our setup, the first await goes through just fine, and the second one blocks forever.

Illustrates the behaviour discussed in https://github.com/MagicStack/asyncpg/issues/68