### PR TITLE
Added test case for an enum inside of an array

### DIFF
--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1161,3 +1161,17 @@ class TestCodecs(tb.ConnectedTestCase):
             await self.con.execute(r'DROP TYPE citext_range')
             await self.con.execute(r'DROP TYPE citext_dom')
             await self.con.execute(r'DROP EXTENSION citext')
+
+    async def test_enum_in_array(self):
+        await self.con.execute('''
+            CREATE TYPE enum_t AS ENUM ('abc', 'def', 'ghi');
+        ''')
+        result = await self.con.fetchrow('''SELECT ARRAY[$1::enum_t];''',
+                                         'abc')
+
+        self.assertEqual(result, ['abc'])
+
+        await self.con.execute('''
+            DROP TYPE enum_t;
+        ''')
+

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1166,6 +1166,10 @@ class TestCodecs(tb.ConnectedTestCase):
         await self.con.execute('''
             CREATE TYPE enum_t AS ENUM ('abc', 'def', 'ghi');
         ''')
+        result = await self.con.fetchrow('''SELECT $1::enum_t[];''',
+                                         ['abc'])
+        self.assertEqual(result, ['abc'])
+
         result = await self.con.fetchrow('''SELECT ARRAY[$1::enum_t];''',
                                          'abc')
 


### PR DESCRIPTION
Right now this PR just adds a test case to demonstrate an issue.

I am not 100%, but it looks like that enum types are just registered with a `PG_FORMAT_TEXT`. However when used inside of an array, it tries to re-register the type for both the `PG_FORMAT_TEXT` and `PG_FORMAT_BINARY` format, which then causes an issue an exception because it's already registeres for the text decoding.


```python
await self.con.execute('''
    CREATE TYPE enum_t AS ENUM ('abc', 'def', 'ghi');
''')
result = await self.con.fetchrow('''SELECT ARRAY[$1::enum_t];''',
                                 'abc')
```

```
======================================================================
ERROR: test_enum_in_array (tests.test_codecs.TestCodecs)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tbartelmess/Developer/asyncpg/asyncpg/_testbase.py", line 65, in wrapper
    self.loop.run_until_complete(__meth__(self, *args, **kwargs))
  File "/Users/tbartelmess/.pyenv/versions/3.6.0/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete
    return future.result()
  File "/Users/tbartelmess/Developer/asyncpg/tests/test_codecs.py", line 1062, in test_enum_in_array
    'abc')
  File "/Users/tbartelmess/Developer/asyncpg/asyncpg/connection.py", line 303, in fetchrow
    stmt = await self._get_statement(query, timeout)
  File "/Users/tbartelmess/Developer/asyncpg/asyncpg/connection.py", line 220, in _get_statement
    protocol.get_settings().register_data_types(types)
  File "asyncpg/protocol/settings.pyx", line 32, in asyncpg.protocol.protocol.ConnectionSettings.register_data_types (asyncpg/protocol/protocol.c:4675)
    cpdef inline register_data_types(self, types):
  File "asyncpg/protocol/settings.pyx", line 33, in asyncpg.protocol.protocol.ConnectionSettings.register_data_types (asyncpg/protocol/protocol.c:4598)
    self._data_codecs.add_types(types)
  File "asyncpg/protocol/codecs/base.pyx", line 470, in asyncpg.protocol.protocol.DataCodecConfig.add_types (asyncpg/protocol/protocol.c:17697)
    self.set_builtin_type_codec(oid, name, schema, 'scalar',
  File "asyncpg/protocol/codecs/base.pyx", line 494, in asyncpg.protocol.protocol.DataCodecConfig.set_builtin_type_codec (asyncpg/protocol/protocol.c:18314)
    raise ValueError('cannot override codec for type {}'.format(
ValueError: cannot override codec for type 16385

----------------------------------------------------------------------
```