### PR TITLE
Add support for the text I/O fallback for arrays of unknown types.

### DIFF
--- a/asyncpg/protocol/buffer.pxd
+++ b/asyncpg/protocol/buffer.pxd
@@ -48,7 +48,7 @@ cdef class WriteBuffer:
     cdef write_bytes(self, bytes data)
     cdef write_bytestring(self, bytes string)
     cdef write_str(self, str string, str encoding)
-    cdef write_cstr(self, char *data, ssize_t len)
+    cdef write_cstr(self, const char *data, ssize_t len)
     cdef write_int16(self, int16_t i)
     cdef write_int32(self, int32_t i)
     cdef write_int64(self, int64_t i)

--- a/asyncpg/protocol/buffer.pyx
+++ b/asyncpg/protocol/buffer.pyx
@@ -169,7 +169,7 @@ cdef class WriteBuffer:
     cdef write_str(self, str string, str encoding):
         self.write_bytestring(string.encode(encoding))
 
-    cdef write_cstr(self, char *data, ssize_t len):
+    cdef write_cstr(self, const char *data, ssize_t len):
         self._check_readonly()
         self._ensure_alloced(len)
 

--- a/asyncpg/protocol/codecs/base.pxd
+++ b/asyncpg/protocol/codecs/base.pxd
@@ -81,6 +81,9 @@ cdef class Codec:
     cdef encode_array(self, ConnectionSettings settings, WriteBuffer buf,
                       object obj)
 
+    cdef encode_array_text(self, ConnectionSettings settings, WriteBuffer buf,
+                           object obj)
+
     cdef encode_range(self, ConnectionSettings settings, WriteBuffer buf,
                       object obj)
 
@@ -137,6 +140,7 @@ cdef class Codec:
     cdef Codec new_composite_codec(uint32_t oid,
                                    str name,
                                    str schema,
+                                   CodecFormat format,
                                    list element_codecs,
                                    tuple element_type_oids,
                                    object element_names)

--- a/asyncpg/protocol/codecs/text.pyx
+++ b/asyncpg/protocol/codecs/text.pyx
@@ -63,5 +63,9 @@ cdef init_text_codecs():
                             <decode_func>&text_decode,
                             PG_FORMAT_BINARY)
 
+        register_core_codec(oid,
+                            <encode_func>&text_encode,
+                            <decode_func>&text_decode,
+                            PG_FORMAT_TEXT)
 
 init_text_codecs()

--- a/asyncpg/protocol/codecs/textutils.pyx
+++ b/asyncpg/protocol/codecs/textutils.pyx
@@ -5,6 +5,12 @@
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
 
+cdef inline uint32_t _apg_tolower(uint32_t c):
+    if c >= <uint32_t><Py_UCS4>'A' and c <= <uint32_t><Py_UCS4>'Z':
+        return c + <uint32_t><Py_UCS4>'a' - <uint32_t><Py_UCS4>'A'
+    else:
+        return c
+
 
 cdef int apg_strcasecmp(const Py_UCS4 *s1, const Py_UCS4 *s2):
     cdef:
@@ -17,13 +23,34 @@ cdef int apg_strcasecmp(const Py_UCS4 *s1, const Py_UCS4 *s2):
         c2 = s2[i]
 
         if c1 != c2:
-            if c1 >= <uint32_t><Py_UCS4>'A' and c1 <= <uint32_t><Py_UCS4>'Z':
-                c1 += <uint32_t><Py_UCS4>'a' - <uint32_t><Py_UCS4>'A'
-            if c2 >= <uint32_t><Py_UCS4>'A' and c2 <= <uint32_t><Py_UCS4>'Z':
-                c2 += <uint32_t><Py_UCS4>'a' - <uint32_t><Py_UCS4>'A'
-
+            c1 = _apg_tolower(c1)
+            c2 = _apg_tolower(c2)
             if c1 != c2:
                 return <int32_t>c1 - <int32_t>c2
+
+        if c1 == 0 or c2 == 0:
+            break
+
+        i += 1
+
+    return 0
+
+
+cdef int apg_strcasecmp_char(const char *s1, const char *s2):
+    cdef:
+        uint8_t c1
+        uint8_t c2
+        int i = 0
+
+    while True:
+        c1 = <uint8_t>s1[i]
+        c2 = <uint8_t>s2[i]
+
+        if c1 != c2:
+            c1 = <uint8_t>_apg_tolower(c1)
+            c2 = <uint8_t>_apg_tolower(c2)
+            if c1 != c2:
+                return <int8_t>c1 - <int8_t>c2
 
         if c1 == 0 or c2 == 0:
             break


### PR DESCRIPTION
Currently, asyncpg supports falling back to text I/O for types that do not have a registered codec.  This commit extends this behaviour to arrays of such types.

Additionally, add an explicit error for when the text I/O is attempted for a range or a composite type, as these are not supported yet.