### PR TITLE
Add rudimentary server capability detection.

### DIFF
--- a/asyncpg/protocol/settings.pyx
+++ b/asyncpg/protocol/settings.pyx
@@ -60,3 +60,6 @@ cdef class ConnectionSettings:
                 raise AttributeError(name) from None
 
         return object.__getattr__(self, name)
+
+    def __repr__(self):
+        return '<ConnectionSettings {!r}>'.format(self._settings)

--- a/asyncpg/types.py
+++ b/asyncpg/types.py
@@ -10,7 +10,7 @@ import collections
 
 __all__ = (
     'Type', 'Attribute', 'Range', 'BitString', 'Point', 'Path', 'Polygon',
-    'Box', 'Line', 'LineSegment', 'Circle', 'ServerVersion'
+    'Box', 'Line', 'LineSegment', 'Circle', 'ServerVersion',
 )
 
 


### PR DESCRIPTION
Add basic server capability detection mechanism based on server version
and parameters reported by the server through ParameterStatus messages.
This allows altering certain asyncpg behaviour based on the connected
server.

Specifically, this allows asyncpg to connect to CockroachDB servers.

Fixes #87.