### PR TITLE
Shield Pool.release() from task cancellation.

### DIFF
--- a/asyncpg/_testbase.py
+++ b/asyncpg/_testbase.py
@@ -128,6 +128,22 @@ def _shutdown_cluster(cluster):
     cluster.destroy()
 
 
+def create_pool(dsn=None, *,
+                min_size=10,
+                max_size=10,
+                max_queries=50000,
+                setup=None,
+                init=None,
+                loop=None,
+                pool_class=pg_pool.Pool,
+                **connect_kwargs):
+    return pool_class(
+        dsn,
+        min_size=min_size, max_size=max_size,
+        max_queries=max_queries, loop=loop, setup=setup, init=init,
+        **connect_kwargs)
+
+
 class ClusterTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -136,10 +152,10 @@ class ClusterTestCase(TestCase):
             'log_connections': 'on'
         })
 
-    def create_pool(self, **kwargs):
+    def create_pool(self, pool_class=pg_pool.Pool, **kwargs):
         conn_spec = self.cluster.get_connection_spec()
         conn_spec.update(kwargs)
-        return pg_pool.create_pool(loop=self.loop, **conn_spec)
+        return create_pool(loop=self.loop, pool_class=pool_class, **conn_spec)
 
     @classmethod
     def start_cluster(cls, ClusterCls, *,

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -526,6 +526,7 @@ async def connect(dsn=None, *,
                   timeout=60,
                   statement_cache_size=100,
                   command_timeout=None,
+                  connection_class=Connection,
                   **opts):
     """A coroutine to establish a connection to a PostgreSQL server.
 
@@ -558,12 +559,16 @@ async def connect(dsn=None, *,
 
     :param float timeout: connection timeout in seconds.
 
+    :param int statement_cache_size: the size of prepared statement LRU cache.
+
     :param float command_timeout: the default timeout for operations on
                           this connection (the default is no timeout).
 
-    :param int statement_cache_size: the size of prepared statement LRU cache.
+    :param builtins.type connection_class: A class used to represent
+                the connection.
+                Defaults to :class:`~asyncpg.connection.Connection`.
 
-    :return: A :class:`~asyncpg.connection.Connection` instance.
+    :return: A *connection_class* instance.
 
     Example:
 
@@ -577,6 +582,10 @@ async def connect(dsn=None, *,
         ...     print(types)
         >>> asyncio.get_event_loop().run_until_complete(run())
         [<Record typname='bool' typnamespace=11 ...
+
+
+    .. versionadded:: 0.10.0
+       *connection_class* argument.
     """
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -620,9 +629,9 @@ async def connect(dsn=None, *,
         tr.close()
         raise
 
-    con = Connection(pr, tr, loop, addr, opts,
-                     statement_cache_size=statement_cache_size,
-                     command_timeout=command_timeout)
+    con = connection_class(pr, tr, loop, addr, opts,
+                           statement_cache_size=statement_cache_size,
+                           command_timeout=command_timeout)
     pr.set_connection(con)
     return con
 


### PR DESCRIPTION
Use asyncio.shield() to guarantee that task cancellation
does not prevent the connection from being returned to the
pool properly.

Fixes: #97.