### PR TITLE
Invalidate statement cache on schema changes affecting statement result.

### DIFF
--- a/asyncpg/exceptions/__init__.py
+++ b/asyncpg/exceptions/__init__.py
@@ -1,10 +1,3 @@
-# Copyright (C) 2016-present the ayncpg authors and contributors
-# <see AUTHORS file>
-#
-# This module is part of asyncpg and is released under
-# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
-
-
 # GENERATED FROM postgresql/src/backend/utils/errcodes.txt
 # DO NOT MODIFY, use tools/generate_exceptions.py to update
 
@@ -90,6 +83,10 @@ class TriggeredActionError(_base.PostgresError):
 
 class FeatureNotSupportedError(_base.PostgresError):
     sqlstate = '0A000'
+
+
+class InvalidCachedStatementError(FeatureNotSupportedError):
+    pass
 
 
 class InvalidTransactionInitiationError(_base.PostgresError):
@@ -1025,15 +1022,16 @@ __all__ = _base.__all__ + (
     'InvalidArgumentForPowerFunctionError',
     'InvalidArgumentForWidthBucketFunctionError',
     'InvalidAuthorizationSpecificationError',
-    'InvalidBinaryRepresentationError', 'InvalidCatalogNameError',
-    'InvalidCharacterValueForCastError', 'InvalidColumnDefinitionError',
-    'InvalidColumnReferenceError', 'InvalidCursorDefinitionError',
-    'InvalidCursorNameError', 'InvalidCursorStateError',
-    'InvalidDatabaseDefinitionError', 'InvalidDatetimeFormatError',
-    'InvalidEscapeCharacterError', 'InvalidEscapeOctetError',
-    'InvalidEscapeSequenceError', 'InvalidForeignKeyError',
-    'InvalidFunctionDefinitionError', 'InvalidGrantOperationError',
-    'InvalidGrantorError', 'InvalidIndicatorParameterValueError',
+    'InvalidBinaryRepresentationError', 'InvalidCachedStatementError',
+    'InvalidCatalogNameError', 'InvalidCharacterValueForCastError',
+    'InvalidColumnDefinitionError', 'InvalidColumnReferenceError',
+    'InvalidCursorDefinitionError', 'InvalidCursorNameError',
+    'InvalidCursorStateError', 'InvalidDatabaseDefinitionError',
+    'InvalidDatetimeFormatError', 'InvalidEscapeCharacterError',
+    'InvalidEscapeOctetError', 'InvalidEscapeSequenceError',
+    'InvalidForeignKeyError', 'InvalidFunctionDefinitionError',
+    'InvalidGrantOperationError', 'InvalidGrantorError',
+    'InvalidIndicatorParameterValueError',
     'InvalidLocatorSpecificationError', 'InvalidNameError',
     'InvalidObjectDefinitionError', 'InvalidParameterValueError',
     'InvalidPasswordError', 'InvalidPreparedStatementDefinitionError',

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -402,6 +402,12 @@ class Pool:
         if self._closed:
             raise exceptions.InterfaceError('pool is closed')
 
+    def _drop_statement_cache(self):
+        # Drop statement cache for all connections in the pool.
+        for ch in self._holders:
+            if ch._con is not None:
+                ch._con._drop_local_statement_cache()
+
     def __await__(self):
         return self._async__init__().__await__()
 

--- a/asyncpg/prepared_stmt.py
+++ b/asyncpg/prepared_stmt.py
@@ -154,11 +154,7 @@ class PreparedStatement:
 
         :return: A list of :class:`Record` instances.
         """
-        self.__check_open()
-        protocol = self._connection._protocol
-        data, status, _ = await protocol.bind_execute(
-            self._state, args, '', 0, True, timeout)
-        self._last_status = status
+        data = await self.__bind_execute(args, 0, timeout)
         return data
 
     async def fetchval(self, *args, column=0, timeout=None):
@@ -174,11 +170,7 @@ class PreparedStatement:
 
         :return: The value of the specified column of the first record.
         """
-        self.__check_open()
-        protocol = self._connection._protocol
-        data, status, _ = await protocol.bind_execute(
-            self._state, args, '', 1, True, timeout)
-        self._last_status = status
+        data = await self.__bind_execute(args, 1, timeout)
         if not data:
             return None
         return data[0][column]
@@ -192,14 +184,18 @@ class PreparedStatement:
 
         :return: The first row as a :class:`Record` instance.
         """
-        self.__check_open()
-        protocol = self._connection._protocol
-        data, status, _ = await protocol.bind_execute(
-            self._state, args, '', 1, True, timeout)
-        self._last_status = status
+        data = await self.__bind_execute(args, 1, timeout)
         if not data:
             return None
         return data[0]
+
+    async def __bind_execute(self, args, limit, timeout):
+        self.__check_open()
+        protocol = self._connection._protocol
+        data, status, _ = await protocol.bind_execute(
+            self._state, args, '', limit, True, timeout)
+        self._last_status = status
+        return data
 
     def __check_open(self):
         if self._state.closed:

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -121,7 +121,9 @@ cdef class BaseProtocol(CoreProtocol):
         return self.settings
 
     def is_in_transaction(self):
-        return self.xact_status == PQTRANS_INTRANS
+        # PQTRANS_INTRANS = idle, within transaction block
+        # PQTRANS_INERROR = idle, within failed transaction
+        return self.xact_status in (PQTRANS_INTRANS, PQTRANS_INERROR)
 
     async def prepare(self, stmt_name, query, timeout):
         if self.cancel_waiter is not None:

--- a/tests/test_cache_invalidation.py
+++ b/tests/test_cache_invalidation.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2016-present the ayncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import asyncpg
+from asyncpg import _testbase as tb
+
+
+class TestCacheInvalidation(tb.ConnectedTestCase):
+    async def test_prepare_cache_invalidation_silent(self):
+        await self.con.execute('CREATE TABLE tab1(a int, b int)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, 2)')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, 2))
+
+            await self.con.execute(
+                'ALTER TABLE tab1 ALTER COLUMN b SET DATA TYPE text')
+
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, '2'))
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+
+    async def test_prepare_cache_invalidation_in_transaction(self):
+        await self.con.execute('CREATE TABLE tab1(a int, b int)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, 2)')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, 2))
+
+            await self.con.execute(
+                'ALTER TABLE tab1 ALTER COLUMN b SET DATA TYPE text')
+
+            with self.assertRaisesRegex(asyncpg.InvalidCachedStatementError,
+                                        'cached statement plan is invalid'):
+                async with self.con.transaction():
+                    result = await self.con.fetchrow('SELECT * FROM tab1')
+
+            # This is now OK,
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, '2'))
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+
+    async def test_prepare_cache_invalidation_in_pool(self):
+        pool = await self.create_pool(database='postgres',
+                                      min_size=2, max_size=2)
+
+        await self.con.execute('CREATE TABLE tab1(a int, b int)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, 2)')
+
+            con1 = await pool.acquire()
+            con2 = await pool.acquire()
+
+            result = await con1.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, 2))
+
+            result = await con2.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, 2))
+
+            await self.con.execute(
+                'ALTER TABLE tab1 ALTER COLUMN b SET DATA TYPE text')
+
+            # con1 tries the same plan, will invalidate the cache
+            # for the entire pool.
+            result = await con1.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, '2'))
+
+            async with con2.transaction():
+                # This should work, as con1 should have invalidated
+                # the plan cache.
+                result = await con2.fetchrow('SELECT * FROM tab1')
+                self.assertEqual(result, (1, '2'))
+
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await pool.close()


### PR DESCRIPTION
PostgreSQL will raise an exception when it detects that the result type of the
query has changed from when the statement was prepared.  This may happen, for
example, after an ALTER TABLE or SET search_path.

When this happens, and there is no transaction running, we can simply
re-prepare the statement and try again.

If the transaction _is_ running, this error will put it into an error state,
and we have no choice but to raise an exception.  The original error is
somewhat cryptic, so we raise a custom InvalidCachedStatementError with the
original server exception as context.

In either case we clear the statement cache for this connection and all other
connections of the pool this connection belongs to (if any).

See #72 and #76 for discussion.

Fixes: #72.