### PR TITLE
Implement conistent handling of timeouts.

### DIFF
--- a/asyncpg/protocol/__init__.py
+++ b/asyncpg/protocol/__init__.py
@@ -5,4 +5,4 @@
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
 
-from .protocol import Protocol, Record  # NOQA
+from .protocol import Protocol, Record, NO_TIMEOUT  # NOQA

--- a/asyncpg/protocol/protocol.pxd
+++ b/asyncpg/protocol/protocol.pxd
@@ -47,7 +47,8 @@ cdef class BaseProtocol(CoreProtocol):
 
         PreparedStatementState statement
 
-    cdef _ensure_clear_state(self)
+    cdef _get_timeout_impl(self, timeout)
+    cdef _check_state(self)
     cdef _new_waiter(self, timeout)
 
     cdef _on_result__connect(self, object waiter)


### PR DESCRIPTION
The timeout logic is currently a bit of a mess.  This commit attempts to
tidy things up.

Most importantly, the timeout budget is now applied consistently to the
_entire_ call, whereas previously multiple consecutive operations used
the same timeout value, making it possible for the overall run time to
exceed the timeout.

Secondly, tighten the validation for timeouts: booleans are not
accepted, and neither any value that cannot be converted to float.