### PR TITLE
Add support for COPY OUT

### DIFF
--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -6,7 +6,11 @@
 
 
 import functools
+import os
 import sys
+
+
+PY_36 = sys.version_info >= (3, 6)
 
 
 if sys.version_info < (3, 5, 2):
@@ -18,3 +22,26 @@ if sys.version_info < (3, 5, 2):
 else:
     def aiter_compat(func):
         return func
+
+
+if PY_36:
+    fspath = os.fspath
+else:
+    def fspath(path):
+        fsp = getattr(path, '__fspath__', None)
+        if fsp is not None and callable(fsp):
+            path = fsp()
+            if not isinstance(path, (str, bytes)):
+                raise TypeError(
+                    'expected {}() to return str or bytes, not {}'.format(
+                        fsp.__qualname__, type(path).__name__
+                    ))
+            return path
+        elif isinstance(path, (str, bytes)):
+            return path
+        else:
+            raise TypeError(
+                'expected str, bytes or path-like object, not {}'.format(
+                    type(path).__name__
+                )
+            )

--- a/asyncpg/protocol/buffer.pxd
+++ b/asyncpg/protocol/buffer.pxd
@@ -99,14 +99,17 @@ cdef class ReadBuffer:
     cdef _switch_to_next_buf(self)
     cdef inline read_byte(self)
     cdef inline char* _try_read_bytes(self, ssize_t nbytes)
-    cdef inline read(self, ssize_t nbytes)
+    cdef inline _read(self, char *buf, ssize_t nbytes)
+    cdef read(self, ssize_t nbytes)
     cdef inline read_bytes(self, ssize_t n)
     cdef inline read_int32(self)
     cdef inline read_int16(self)
     cdef inline read_cstr(self)
     cdef int32_t has_message(self) except -1
+    cdef inline int32_t has_message_type(self, char mtype) except -1
     cdef inline char* try_consume_message(self, ssize_t* len)
     cdef Memory consume_message(self)
+    cdef bytearray consume_messages(self, char mtype)
     cdef discard_message(self)
     cdef inline _discard_message(self)
     cdef inline char get_message_type(self)

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -15,8 +15,8 @@ cdef enum ProtocolState:
     PROTOCOL_IDLE = 0
 
     PROTOCOL_FAILED = 1
-
     PROTOCOL_ERROR_CONSUME = 2
+    PROTOCOL_CANCELLED = 3
 
     PROTOCOL_AUTH = 10
     PROTOCOL_PREPARE = 11
@@ -26,6 +26,11 @@ cdef enum ProtocolState:
     PROTOCOL_SIMPLE_QUERY = 15
     PROTOCOL_EXECUTE = 16
     PROTOCOL_BIND = 17
+    PROTOCOL_COPY_OUT = 18
+    PROTOCOL_COPY_OUT_DATA = 19
+    PROTOCOL_COPY_OUT_DONE = 20
+    PROTOCOL_COPY_IN = 21
+    PROTOCOL_COPY_IN_DATA = 22
 
 
 cdef enum AuthenticationMessage:
@@ -106,6 +111,8 @@ cdef class CoreProtocol:
     cdef _process__close_stmt_portal(self, char mtype)
     cdef _process__simple_query(self, char mtype)
     cdef _process__bind(self, char mtype)
+    cdef _process__copy_out(self, char mtype)
+    cdef _process__copy_out_data(self, char mtype)
 
     cdef _parse_msg_authentication(self)
     cdef _parse_msg_parameter_status(self)
@@ -113,6 +120,7 @@ cdef class CoreProtocol:
     cdef _parse_msg_backend_key_data(self)
     cdef _parse_msg_ready_for_query(self)
     cdef _parse_data_msgs(self)
+    cdef _parse_copy_data_msgs(self)
     cdef _parse_msg_error_response(self, is_error)
     cdef _parse_msg_command_complete(self)
 
@@ -148,6 +156,7 @@ cdef class CoreProtocol:
     cdef _execute(self, str portal_name, int32_t limit)
     cdef _close(self, str name, bint is_portal)
     cdef _simple_query(self, str query)
+    cdef _copy_out(self, str copy_stmt)
     cdef _terminate(self)
 
     cdef _decode_row(self, const char* buf, ssize_t buf_len)

--- a/asyncpg/protocol/protocol.pxd
+++ b/asyncpg/protocol/protocol.pxd
@@ -37,6 +37,7 @@ cdef class BaseProtocol(CoreProtocol):
         object timeout_callback
         object completed_callback
         object connection
+        bint is_reading
 
         str last_query
 
@@ -56,7 +57,11 @@ cdef class BaseProtocol(CoreProtocol):
     cdef _on_result__close_stmt_or_portal(self, object waiter)
     cdef _on_result__simple_query(self, object waiter)
     cdef _on_result__bind(self, object waiter)
+    cdef _on_result__copy_out(self, object waiter)
 
     cdef _handle_waiter_on_connection_lost(self, cause)
 
     cdef _dispatch_result(self)
+
+    cdef inline resume_reading(self)
+    cdef inline pause_reading(self)

--- a/asyncpg/protocol/python.pxd
+++ b/asyncpg/protocol/python.pxd
@@ -14,9 +14,13 @@ cdef extern from "Python.h":
     void PyMem_Free(void *p)
 
     int PyByteArray_Check(object)
+    ssize_t PyByteArray_Size(object)
+    int PyByteArray_Resize(object, ssize_t)
+    object PyByteArray_FromStringAndSize(const char *, ssize_t)
 
     int PyMemoryView_Check(object)
     Py_buffer *PyMemoryView_GET_BUFFER(object)
+    object PyMemoryView_FromMemory(char *mem, ssize_t size, int flags)
 
     char* PyUnicode_AsUTF8AndSize(object unicode, ssize_t *size) except NULL
     char* PyByteArray_AsString(object)

--- a/asyncpg/utils.py
+++ b/asyncpg/utils.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2016-present the ayncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import re
+
+
+def _quote_ident(ident):
+    return '"{}"'.format(ident.replace('"', '""'))
+
+
+def _quote_literal(string):
+    return "'{}'".format(string.replace("'", "''"))
+
+
+async def _mogrify(conn, query, args):
+    """Safely inline arguments to query text."""
+    # Introspect the target query for argument types and
+    # build a list of safely-quoted fully-qualified type names.
+    ps = await conn.prepare(query)
+    paramtypes = []
+    for t in ps.get_parameters():
+        if t.name.endswith('[]'):
+            pname = '_' + t.name[:-2]
+        else:
+            pname = t.name
+
+        paramtypes.append('{}.{}'.format(
+            _quote_ident(t.schema), _quote_ident(pname)))
+    del ps
+
+    # Use Postgres to convert arguments to text representation
+    # by casting each value to text.
+    cols = ['quote_literal(${}::{}::text)'.format(i, t)
+            for i, t in enumerate(paramtypes, start=1)]
+
+    textified = await conn.fetchrow(
+        'SELECT {cols}'.format(cols=', '.join(cols)), *args)
+
+    # Finally, replace $n references with text values.
+    return re.sub(
+        r'\$(\d+)\b', lambda m: textified[int(m.group(1)) - 1], query)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinx.ext.intersphinx',
     'sphinxcontrib.asyncio',
 ]
 
@@ -91,3 +92,7 @@ texinfo_documents = [
      'Python asyncio framework',
      'Miscellaneous'),
 ]
+
+# -- Options for intersphinx ----------------------------------------------
+
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,355 @@
+# Copyright (C) 2016-present the asyncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import asyncio
+import io
+import tempfile
+
+from asyncpg import _testbase as tb
+
+
+class TestCopy(tb.ConnectedTestCase):
+
+    async def test_copy_from_table_basics(self):
+        await self.con.execute('''
+            CREATE TABLE copytab(a text, "b~" text, i int);
+            INSERT INTO copytab (a, "b~", i) (
+                SELECT 'a' || i::text, 'b' || i::text, i
+                FROM generate_series(1, 5) AS i
+            );
+            INSERT INTO copytab (a, "b~", i) VALUES('*', NULL, NULL);
+        ''')
+
+        try:
+            f = io.BytesIO()
+
+            # Basic functionality.
+            res = await self.con.copy_from_table('copytab', output=f)
+
+            self.assertEqual(res, 'COPY 6')
+
+            output = f.getvalue().decode().split('\n')
+            self.assertEqual(
+                output,
+                [
+                    'a1\tb1\t1',
+                    'a2\tb2\t2',
+                    'a3\tb3\t3',
+                    'a4\tb4\t4',
+                    'a5\tb5\t5',
+                    '*\t\\N\t\\N',
+                    ''
+                ]
+            )
+
+            # Test parameters.
+            await self.con.execute('SET search_path=none')
+
+            f.seek(0)
+            f.truncate()
+
+            res = await self.con.copy_from_table(
+                'copytab', output=f, columns=('a', 'b~'),
+                schema_name='public', format='csv',
+                delimiter='|', null='n-u-l-l', header=True,
+                quote='*', escape='!', force_quote=('a',))
+
+            output = f.getvalue().decode().split('\n')
+
+            self.assertEqual(
+                output,
+                [
+                    'a|b~',
+                    '*a1*|b1',
+                    '*a2*|b2',
+                    '*a3*|b3',
+                    '*a4*|b4',
+                    '*a5*|b5',
+                    '*!**|n-u-l-l',
+                    ''
+                ]
+            )
+
+            await self.con.execute('SET search_path=public')
+        finally:
+            await self.con.execute('DROP TABLE public.copytab')
+
+    async def test_copy_from_table_large_rows(self):
+        await self.con.execute('''
+            CREATE TABLE copytab(a text, b text);
+            INSERT INTO copytab (a, b) (
+                SELECT
+                    repeat('a' || i::text, 500000),
+                    repeat('b' || i::text, 500000)
+                FROM
+                    generate_series(1, 5) AS i
+            );
+        ''')
+
+        try:
+            f = io.BytesIO()
+
+            # Basic functionality.
+            res = await self.con.copy_from_table('copytab', output=f)
+
+            self.assertEqual(res, 'COPY 5')
+
+            output = f.getvalue().decode().split('\n')
+            self.assertEqual(
+                output,
+                [
+                    'a1' * 500000 + '\t' + 'b1' * 500000,
+                    'a2' * 500000 + '\t' + 'b2' * 500000,
+                    'a3' * 500000 + '\t' + 'b3' * 500000,
+                    'a4' * 500000 + '\t' + 'b4' * 500000,
+                    'a5' * 500000 + '\t' + 'b5' * 500000,
+                    ''
+                ]
+            )
+        finally:
+            await self.con.execute('DROP TABLE public.copytab')
+
+    async def test_copy_from_query_basics(self):
+        f = io.BytesIO()
+
+        res = await self.con.copy_from_query('''
+            SELECT
+                repeat('a' || i::text, 500000),
+                repeat('b' || i::text, 500000)
+            FROM
+                generate_series(1, 5) AS i
+        ''', output=f)
+
+        self.assertEqual(res, 'COPY 5')
+
+        output = f.getvalue().decode().split('\n')
+        self.assertEqual(
+            output,
+            [
+                'a1' * 500000 + '\t' + 'b1' * 500000,
+                'a2' * 500000 + '\t' + 'b2' * 500000,
+                'a3' * 500000 + '\t' + 'b3' * 500000,
+                'a4' * 500000 + '\t' + 'b4' * 500000,
+                'a5' * 500000 + '\t' + 'b5' * 500000,
+                ''
+            ]
+        )
+
+    async def test_copy_from_query_with_args(self):
+        f = io.BytesIO()
+
+        res = await self.con.copy_from_query('''
+            SELECT
+                i, i * 10
+            FROM
+                generate_series(1, 5) AS i
+            WHERE
+                i = $1
+        ''', 3, output=f)
+
+        self.assertEqual(res, 'COPY 1')
+
+        output = f.getvalue().decode().split('\n')
+        self.assertEqual(
+            output,
+            [
+                '3\t30',
+                ''
+            ]
+        )
+
+    async def test_copy_from_query_to_path(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.close()
+            await self.con.copy_from_query('''
+                SELECT
+                    i, i * 10
+                FROM
+                    generate_series(1, 5) AS i
+                WHERE
+                    i = $1
+            ''', 3, output=f.name)
+
+            with open(f.name, 'rb') as fr:
+                output = fr.read().decode().split('\n')
+                self.assertEqual(
+                    output,
+                    [
+                        '3\t30',
+                        ''
+                    ]
+                )
+
+    async def test_copy_from_query_to_path_like(self):
+        with tempfile.NamedTemporaryFile() as f:
+            f.close()
+
+            class Path:
+                def __init__(self, path):
+                    self.path = path
+
+                def __fspath__(self):
+                    return self.path
+
+            await self.con.copy_from_query('''
+                SELECT
+                    i, i * 10
+                FROM
+                    generate_series(1, 5) AS i
+                WHERE
+                    i = $1
+            ''', 3, output=Path(f.name))
+
+            with open(f.name, 'rb') as fr:
+                output = fr.read().decode().split('\n')
+                self.assertEqual(
+                    output,
+                    [
+                        '3\t30',
+                        ''
+                    ]
+                )
+
+    async def test_copy_from_query_to_bad_output(self):
+        with self.assertRaisesRegexp(TypeError, 'output is expected to be'):
+            await self.con.copy_from_query('''
+                SELECT
+                    i, i * 10
+                FROM
+                    generate_series(1, 5) AS i
+                WHERE
+                    i = $1
+            ''', 3, output=1)
+
+    async def test_copy_from_query_to_sink(self):
+        with tempfile.NamedTemporaryFile() as f:
+            async def writer(data):
+                # Sleeping here to simulate slow output sink to test
+                # backpressure.
+                await asyncio.sleep(0.05, loop=self.loop)
+                f.write(data)
+
+            await self.con.copy_from_query('''
+                SELECT
+                    repeat('a', 500)
+                FROM
+                    generate_series(1, 5000) AS i
+            ''', output=writer)
+
+            f.seek(0)
+
+            output = f.read().decode().split('\n')
+            self.assertEqual(
+                output,
+                [
+                    'a' * 500
+                ] * 5000 + ['']
+            )
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)
+
+    async def test_copy_from_query_cancellation_explicit(self):
+        async def writer(data):
+            # Sleeping here to simulate slow output sink to test
+            # backpressure.
+            await asyncio.sleep(0.5, loop=self.loop)
+
+        coro = self.con.copy_from_query('''
+            SELECT
+                repeat('a', 500)
+            FROM
+                generate_series(1, 5000) AS i
+        ''', output=writer)
+
+        task = self.loop.create_task(coro)
+        await asyncio.sleep(0.7, loop=self.loop)
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)
+
+    async def test_copy_from_query_cancellation_on_sink_error(self):
+        async def writer(data):
+            await asyncio.sleep(0.05, loop=self.loop)
+            raise RuntimeError('failure')
+
+        coro = self.con.copy_from_query('''
+            SELECT
+                repeat('a', 500)
+            FROM
+                generate_series(1, 5000) AS i
+        ''', output=writer)
+
+        task = self.loop.create_task(coro)
+
+        with self.assertRaises(RuntimeError):
+            await task
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)
+
+    async def test_copy_from_query_cancellation_while_waiting_for_data(self):
+        async def writer(data):
+            pass
+
+        coro = self.con.copy_from_query('''
+            SELECT
+                pg_sleep(60)
+            FROM
+                generate_series(1, 5000) AS i
+        ''', output=writer)
+
+        task = self.loop.create_task(coro)
+        await asyncio.sleep(0.7, loop=self.loop)
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)
+
+    async def test_copy_from_query_timeout_1(self):
+        async def writer(data):
+            await asyncio.sleep(0.05, loop=self.loop)
+
+        coro = self.con.copy_from_query('''
+            SELECT
+                repeat('a', 500)
+            FROM
+                generate_series(1, 5000) AS i
+        ''', output=writer, timeout=0.10)
+
+        task = self.loop.create_task(coro)
+
+        with self.assertRaises(asyncio.TimeoutError):
+            await task
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)
+
+    async def test_copy_from_query_timeout_2(self):
+        async def writer(data):
+            try:
+                await asyncio.sleep(10, loop=self.loop)
+            except asyncio.TimeoutError:
+                raise
+            else:
+                self.fail('TimeoutError not raised')
+
+        coro = self.con.copy_from_query('''
+            SELECT
+                repeat('a', 500)
+            FROM
+                generate_series(1, 5000) AS i
+        ''', output=writer, timeout=0.10)
+
+        task = self.loop.create_task(coro)
+
+        with self.assertRaises(asyncio.TimeoutError):
+            await task
+
+        self.assertEqual(await self.con.fetchval('SELECT 1'), 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2016-present the ayncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import datetime
+
+from asyncpg import utils
+from asyncpg import _testbase as tb
+
+
+class TestUtils(tb.ConnectedTestCase):
+
+    async def test_mogrify_simple(self):
+        cases = [
+            ('timestamp',
+                datetime.datetime(2016, 10, 10),
+                "SELECT '2016-10-10 00:00:00'::timestamp"),
+            ('int[]',
+                [[1, 2], [3, 4]],
+                "SELECT '{{1,2},{3,4}}'::int[]"),
+        ]
+
+        for typename, data, expected in cases:
+            with self.subTest(value=data, type=typename):
+                mogrified = await utils._mogrify(
+                    self.con, 'SELECT $1::{}'.format(typename), [data])
+                self.assertEqual(mogrified, expected)
+
+    async def test_mogrify_multiple(self):
+        mogrified = await utils._mogrify(
+            self.con, 'SELECT $1::int, $2::int[]',
+            [1, [2, 3, 4, 5]])
+        expected = "SELECT '1'::int, '{2,3,4,5}'::int[]"
+        self.assertEqual(mogrified, expected)


### PR DESCRIPTION
This commit adds two new Connection methods: copy_from_table() and
copy_from_query() that allow copying the contents of a table or
the results of a query using PostgreSQL COPY protocol.

Issue #21.