### PR TITLE
don't install pyx or c files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -202,9 +202,8 @@ setuptools.setup(
     author_email='hello@magic.io',
     url='https://github.com/MagicStack/asyncpg',
     license='Apache License, Version 2.0',
-    packages=['asyncpg'],
+    packages=setuptools.find_packages(),
     provides=['asyncpg'],
-    include_package_data=True,
     ext_modules=[
         setuptools.Extension(
             "asyncpg.protocol.protocol",


### PR DESCRIPTION
`include_package_data=True` causes the `*.pyx` and `*.c` files to be installed in the site-packages directory, which are not necessary at run time.  This option is also causing the sub-modules to be included, so use `find_packages` to scan for them instead.