### PR TITLE
Fix integer boundaries

### DIFF
--- a/asyncpg/protocol/codecs/int.pyx
+++ b/asyncpg/protocol/codecs/int.pyx
@@ -20,7 +20,7 @@ cdef bool_decode(ConnectionSettings settings, FastReadBuffer buf):
 
 cdef int2_encode(ConnectionSettings settings, WriteBuffer buf, obj):
     cdef long val = cpython.PyLong_AsLong(obj)
-    if val < -32767 or val > 32767:
+    if val < -32768 or val > 32767:
         raise ValueError(
             'integer too large to be encoded as INT2: {!r}'.format(val))
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -472,7 +472,11 @@ class TestCodecs(tb.ConnectedTestCase):
                 '2',
                 'aa',
             ]),
-            ('smallint', ValueError, 'integer too large', [
+            ('smallint', OverflowError, 'int too big to be encoded as INT2', [
+                2**256,  # check for the same exception for any big numbers
+                decimal.Decimal("2000000000000000000000000000000"),
+                0xffff,
+                0xffffffff,
                 32768,
                 -32769
             ]),
@@ -484,9 +488,23 @@ class TestCodecs(tb.ConnectedTestCase):
                 '2',
                 'aa',
             ]),
+            ('int', OverflowError, 'int too big to be encoded as INT4', [
+                2**256,  # check for the same exception for any big numbers
+                decimal.Decimal("2000000000000000000000000000000"),
+                0xffffffff,
+                2**31,
+                -2**31 - 1,
+            ]),
             ('int8', TypeError, 'an integer is required', [
                 '2',
                 'aa',
+            ]),
+            ('bigint', OverflowError, 'int too big to be encoded as INT8', [
+                2**256,  # check for the same exception for any big numbers
+                decimal.Decimal("2000000000000000000000000000000"),
+                0xffffffffffffffff,
+                2**63,
+                -2**63 - 1,
             ]),
             ('text', TypeError, 'expected str, got bytes', [
                 b'foo'

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -37,15 +37,15 @@ type_samples = [
         True, False,
     )),
     ('smallint', 'int2', (
-        -2 ** 15 + 1, 2 ** 15 - 1,
+        -2 ** 15, 2 ** 15 - 1,
         -1, 0, 1,
     )),
     ('int', 'int4', (
-        -2 ** 31 + 1, 2 ** 31 - 1,
+        -2 ** 31, 2 ** 31 - 1,
         -1, 0, 1,
     )),
     ('bigint', 'int8', (
-        -2 ** 63 + 1, 2 ** 63 - 1,
+        -2 ** 63, 2 ** 63 - 1,
         -1, 0, 1,
     )),
     ('numeric', 'numeric', (
@@ -474,7 +474,7 @@ class TestCodecs(tb.ConnectedTestCase):
             ]),
             ('smallint', ValueError, 'integer too large', [
                 32768,
-                -32768
+                -32769
             ]),
             ('float4', ValueError, 'float value too large', [
                 4.1 * 10 ** 40,


### PR DESCRIPTION
During development I got strange results when some integer values are passed as query parameters.
I expected `0xfffffffe` as `int4` should raise an exception, but it saved as "-2". Moreover, `0xffffffffe` (there is one "`f`" more) gave the same result.

It was understandable that it is a result of a wrong typecasting.
Debugging led to this PR. Almost all comments are in commit messages.

Firstly I tried to use `PyLong_AsLongAndOverflow` and `PyLong_AsLongLongAndOverflow` but could not reraise exceptions if they are not connected with overflowing. That is why "`try..except`" is used here.

To make the code be compatible between systems I use `sizeof(val) > X` to make a compiler optimize the rest of a condition.

Also I think it is wise to have the same exception among all ranges (previously either `ValueError` or `OverflowError` raised depending on how big passed value is).