### PR TITLE
Add API for receiving asynchronous notices

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -918,7 +918,7 @@ class Connection(metaclass=ConnectionMeta):
         else:
             # `_proxy` is not None when the connection is a member
             # of a connection pool.  Which means that the user is working
-            # with a PooledConnectionProxy instance, and expects to see it
+            # with a `PoolConnectionProxy` instance, and expects to see it
             # (and not the actual Connection) in their event callbacks.
             con_ref = self._proxy
 

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -21,6 +21,7 @@ class PostgresMessageMeta(type):
     _message_map = {}
     _field_map = {
         'S': 'severity',
+        'V': 'severity_en',
         'C': 'sqlstate',
         'M': 'message',
         'D': 'detail',

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -9,7 +9,7 @@ import sys
 
 
 __all__ = ('PostgresError', 'FatalPostgresError', 'UnknownPostgresError',
-           'InterfaceError')
+           'InterfaceError', 'PostgresNotice')
 
 
 def _is_asyncpg_class(cls):
@@ -151,3 +151,10 @@ class UnknownPostgresError(FatalPostgresError):
 
 class InterfaceError(Exception):
     """An error caused by improper use of asyncpg API."""
+
+
+class PostgresNotice(PostgresMessage):
+    sqlstate = '00000'
+
+    def __init__(self, message):
+        self.args = [message]

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -127,6 +127,15 @@ class PostgresMessage(metaclass=PostgresMessageMeta):
 
         return e
 
+    def as_dict(self):
+        message = {}
+        for f in type(self)._field_map.values():
+            val = getattr(self, f)
+            if val is not None:
+                message[f] = val
+
+        return message
+
 
 class PostgresError(PostgresMessage, Exception):
     """Base class for all Postgres errors."""

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -170,5 +170,6 @@ cdef class CoreProtocol:
 
     cdef _on_result(self)
     cdef _on_notification(self, pid, channel, payload)
+    cdef _on_notice(self, parsed)
     cdef _set_server_parameter(self, name, val)
     cdef _on_connection_lost(self, exc)

--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -56,6 +56,10 @@ cdef class CoreProtocol:
                     # NotificationResponse
                     self._parse_msg_notification()
                     continue
+                elif mtype == b'N':
+                    # 'N' - NoticeResponse
+                    self._on_notice(self._parse_msg_error_response(False))
+                    continue
 
                 if state == PROTOCOL_AUTH:
                     self._process__auth(mtype)
@@ -302,10 +306,9 @@ cdef class CoreProtocol:
             self._push_result()
 
     cdef _process__simple_query(self, char mtype):
-        if mtype in {b'D', b'I', b'N', b'T'}:
+        if mtype in {b'D', b'I', b'T'}:
             # 'D' - DataRow
             # 'I' - EmptyQueryResponse
-            # 'N' - NoticeResponse
             # 'T' - RowDescription
             self.buffer.consume_message()
 
@@ -614,6 +617,8 @@ cdef class CoreProtocol:
         if is_error:
             self.result_type = RESULT_FAILED
             self.result = parsed
+        else:
+            return parsed
 
     cdef _push_result(self):
         try:
@@ -908,6 +913,9 @@ cdef class CoreProtocol:
         pass
 
     cdef _on_result(self):
+        pass
+
+    cdef _on_notice(self, parsed):
         pass
 
     cdef _on_notification(self, pid, channel, payload):

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -731,6 +731,14 @@ cdef class BaseProtocol(CoreProtocol):
             self.last_query = None
             self.return_extra = False
 
+    cdef _on_notice(self, parsed):
+        # Check it here to avoid unnecessary object creation.
+        if self.connection._notice_callbacks:
+            message = apg_exc_base.PostgresMessage.new(
+                parsed, query=self.last_query)
+
+            self.connection._notice(message)
+
     cdef _on_notification(self, pid, channel, payload):
         self.connection._notify(pid, channel, payload)
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -131,7 +131,7 @@ class TestPool(tb.ConnectedTestCase):
         cons = set()
 
         async def setup(con):
-            if con._con not in cons:  # `con` is `PooledConnectionProxy`.
+            if con._con not in cons:  # `con` is `PoolConnectionProxy`.
                 raise RuntimeError('init was not called before setup')
 
         async def init(con):
@@ -141,7 +141,7 @@ class TestPool(tb.ConnectedTestCase):
 
         async def user(pool):
             async with pool.acquire() as con:
-                if con._con not in cons:  # `con` is `PooledConnectionProxy`.
+                if con._con not in cons:  # `con` is `PoolConnectionProxy`.
                     raise RuntimeError('init was not called')
 
         async with self.create_pool(database='postgres',


### PR DESCRIPTION
Per request #144.

It seems I implemented it long time ago, but did not have enough time to finalize it as a PR.
I think a single callback per connection is enough, therefore API has just `set_notice_callback` instead of `add_notice_callback` and `remove_notice_callback`.

P.S.: Here is also two minor commits small enough to create separated PRs.