### PR TITLE
Fix Record.keys() and Record.items() to correctly handle duplicate field names.

### DIFF
--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -455,7 +455,7 @@ record_keys(PyObject *o, PyObject *args)
         return NULL;
     }
 
-    return PyObject_GetIter(((ApgRecordObject*)o)->desc->mapping);
+    return PyObject_GetIter(((ApgRecordObject*)o)->desc->keys);
 }
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -298,6 +298,7 @@ class TestRecord(tb.ConnectedTestCase):
         self.assertEqual(r['a'], 2)
         self.assertEqual(r[0], 1)
         self.assertEqual(repr(r), '<Record a=1 a=2>')
+        self.assertEqual(list(r.items()), [('a', 1), ('a', 2)])
 
     async def test_record_isinstance(self):
         """Test that Record works with isinstance."""


### PR DESCRIPTION
Fixes #28.