### PR TITLE
Make sure set_type_codec() overrides core codec for all formats.

### DIFF
--- a/asyncpg/protocol/codecs/base.pxd
+++ b/asyncpg/protocol/codecs/base.pxd
@@ -161,3 +161,5 @@ cdef class DataCodecConfig:
         dict _local_type_codecs
 
     cdef inline Codec get_codec(self, uint32_t oid, CodecFormat format)
+    cdef inline Codec get_local_codec(
+        self, uint32_t oid, CodecFormat preferred_format=*)


### PR DESCRIPTION
When a custom codec is set for a type, it should be called regardless of
whether its format matches the preferred format requested by the
pipeline.

Fixes: #140
Fixes: #148