### PR TITLE
Make interval decoding logic match that of psycopg2.

### DIFF
--- a/asyncpg/protocol/codecs/datetime.pyx
+++ b/asyncpg/protocol/codecs/datetime.pyx
@@ -248,6 +248,7 @@ cdef interval_decode(ConnectionSettings settings, FastReadBuffer buf):
     cdef:
         int32_t days
         int32_t months
+        int32_t years
         int64_t seconds = 0
         uint32_t microseconds = 0
 
@@ -255,8 +256,15 @@ cdef interval_decode(ConnectionSettings settings, FastReadBuffer buf):
     days = hton.unpack_int32(buf.read(4))
     months = hton.unpack_int32(buf.read(4))
 
-    return datetime.timedelta(days=days + months * 30, seconds=seconds,
-                              microseconds=microseconds)
+    if months < 0:
+        years = -<int32_t>(-months // 12)
+        months = -<int32_t>(-months % 12)
+    else:
+        years = <int32_t>(months // 12)
+        months = <int32_t>(months % 12)
+
+    return datetime.timedelta(days=days + months * 30 + years * 365,
+                              seconds=seconds, microseconds=microseconds)
 
 
 cdef init_datetime_codecs():

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -439,6 +439,19 @@ class TestCodecs(tb.ConnectedTestCase):
 
         self.assertEqual(len(bits.bytes), expected_bytelen)
 
+    async def test_interval(self):
+        res = await self.con.fetchval("SELECT '5 years'::interval")
+        self.assertEqual(res, datetime.timedelta(days=1825))
+
+        res = await self.con.fetchval("SELECT '5 years 1 month'::interval")
+        self.assertEqual(res, datetime.timedelta(days=1855))
+
+        res = await self.con.fetchval("SELECT '-5 years'::interval")
+        self.assertEqual(res, datetime.timedelta(days=-1825))
+
+        res = await self.con.fetchval("SELECT '-5 years -1 month'::interval")
+        self.assertEqual(res, datetime.timedelta(days=-1855))
+
     async def test_unhandled_type_fallback(self):
         await self.con.execute('''
             CREATE EXTENSION IF NOT EXISTS isn


### PR DESCRIPTION
asyncpg will now treat 12-month interval increments as 365-day spans,
instead of 12*30 day spans.  This matches psycopg2 interval decoding
logic.