### PR TITLE
Refactor Connection.add_notice_callback API.

### DIFF
--- a/asyncpg/exceptions/__init__.py
+++ b/asyncpg/exceptions/__init__.py
@@ -5,7 +5,7 @@ from ._base import *  # NOQA
 from . import _base
 
 
-class PostgresWarning(Warning, _base.PostgresMessage):
+class PostgresWarning(_base.PostgresLogMessage, Warning):
     sqlstate = '01000'
 
 
@@ -259,6 +259,10 @@ class NullValueNoIndicatorParameterError(DataError):
 
 class NumericValueOutOfRangeError(DataError):
     sqlstate = '22003'
+
+
+class SequenceGeneratorLimitExceededError(DataError):
+    sqlstate = '2200H'
 
 
 class StringDataLengthMismatchError(DataError):
@@ -608,6 +612,10 @@ class WrongObjectTypeError(SyntaxOrAccessError):
     sqlstate = '42809'
 
 
+class GeneratedAlwaysError(SyntaxOrAccessError):
+    sqlstate = '428C9'
+
+
 class UndefinedColumnError(SyntaxOrAccessError):
     sqlstate = '42703'
 
@@ -770,6 +778,10 @@ class CantChangeRuntimeParamError(ObjectNotInPrerequisiteStateError):
 
 class LockNotAvailableError(ObjectNotInPrerequisiteStateError):
     sqlstate = '55P03'
+
+
+class UnsafeNewEnumValueUsageError(ObjectNotInPrerequisiteStateError):
+    sqlstate = '55P04'
 
 
 class OperatorInterventionError(_base.PostgresError):
@@ -1007,7 +1019,8 @@ __all__ = _base.__all__ + (
     'FDWUnableToCreateExecutionError', 'FDWUnableToCreateReplyError',
     'FDWUnableToEstablishConnectionError', 'FeatureNotSupportedError',
     'ForeignKeyViolationError', 'FunctionExecutedNoReturnStatementError',
-    'GroupingError', 'HeldCursorRequiresSameIsolationLevelError',
+    'GeneratedAlwaysError', 'GroupingError',
+    'HeldCursorRequiresSameIsolationLevelError',
     'IdleInTransactionSessionTimeoutError', 'ImplicitZeroBitPadding',
     'InFailedSQLTransactionError',
     'InappropriateAccessModeForBranchTransactionError',
@@ -1073,7 +1086,8 @@ __all__ = _base.__all__ + (
     'ReadingSQLDataNotPermittedError', 'ReservedNameError',
     'RestrictViolationError', 'SQLRoutineError',
     'SQLStatementNotYetCompleteError', 'SavepointError',
-    'SchemaAndDataStatementMixingNotSupportedError', 'SerializationError',
+    'SchemaAndDataStatementMixingNotSupportedError',
+    'SequenceGeneratorLimitExceededError', 'SerializationError',
     'SnapshotTooOldError', 'SrfProtocolViolatedError',
     'StackedDiagnosticsAccessedWithoutActiveHandlerError',
     'StatementCompletionUnknownError', 'StatementTooComplexError',
@@ -1088,8 +1102,8 @@ __all__ = _base.__all__ + (
     'UndefinedColumnError', 'UndefinedFileError',
     'UndefinedFunctionError', 'UndefinedObjectError',
     'UndefinedParameterError', 'UndefinedTableError',
-    'UniqueViolationError', 'UnterminatedCStringError',
-    'UntranslatableCharacterError', 'WindowingError',
-    'WithCheckOptionViolationError', 'WrongObjectTypeError',
-    'ZeroLengthCharacterStringError'
+    'UniqueViolationError', 'UnsafeNewEnumValueUsageError',
+    'UnterminatedCStringError', 'UntranslatableCharacterError',
+    'WindowingError', 'WithCheckOptionViolationError',
+    'WrongObjectTypeError', 'ZeroLengthCharacterStringError'
 )

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -664,7 +664,7 @@ cdef class BaseProtocol(CoreProtocol):
 
         if self.result_type == RESULT_FAILED:
             if isinstance(self.result, dict):
-                exc = apg_exc_base.PostgresMessage.new(
+                exc = apg_exc_base.PostgresError.new(
                     self.result, query=self.last_query)
             else:
                 exc = self.result
@@ -732,15 +732,10 @@ cdef class BaseProtocol(CoreProtocol):
             self.return_extra = False
 
     cdef _on_notice(self, parsed):
-        # Check it here to avoid unnecessary object creation.
-        if self.connection._notice_callbacks:
-            message = apg_exc_base.PostgresMessage.new(
-                parsed, query=self.last_query)
-
-            self.connection._notice(message)
+        self.connection._process_log_message(parsed, self.last_query)
 
     cdef _on_notification(self, pid, channel, payload):
-        self.connection._notify(pid, channel, payload)
+        self.connection._process_notification(pid, channel, payload)
 
     cdef _on_connection_lost(self, exc):
         if self.closing:

--- a/tools/generate_exceptions.py
+++ b/tools/generate_exceptions.py
@@ -139,7 +139,7 @@ class {clsname}({base}):
         if new_section:
             section_class = clsname
             if clsname == 'PostgresWarning':
-                base = 'Warning, _base.PostgresMessage'
+                base = '_base.PostgresLogMessage, Warning'
             else:
                 if msgtype == 'W':
                     base = 'PostgresWarning'


### PR DESCRIPTION
1. Rename to `Connection.add_log_listener()`
2. Fix `Connection.reset()` to reset log listeners
3. Add a new `PostgresLogMessage` class for log messages
4. Instances of `PostgresLogMessage` are immutable
5. Regenerate `exceptions/__init__`; `PostgresWarning` is now a subclass of `PostgresLogMessage`.