### PR TITLE
Do not split out seconds when decoding interval in tuple mode.

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -798,8 +798,7 @@ class Connection(metaclass=ConnectionMeta):
             +-----------------+---------------------------------------------+
             |  Type           |                Tuple layout                 |
             +=================+=============================================+
-            | ``interval``    | (``months``, ``days``, ``seconds``,         |
-            |                 | ``microseconds``)                           |
+            | ``interval``    | (``months``, ``days``, ``microseconds``)    |
             +-----------------+---------------------------------------------+
             | ``date``        | (``date ordinal relative to Jan 1 2000``,)  |
             |                 | ``-2^31`` for negative infinity timestamp   |
@@ -845,14 +844,13 @@ class Connection(metaclass=ConnectionMeta):
             ...         ndelta = delta.normalized()
             ...         return (ndelta.years * 12 + ndelta.months,
             ...                 ndelta.days,
-            ...                 (ndelta.hours * 3600 +
+            ...                 ((ndelta.hours * 3600 +
             ...                    ndelta.minutes * 60 +
-            ...                    ndelta.seconds),
-            ...                 ndelta.microseconds)
+            ...                    ndelta.seconds) * 1000000 +
+            ...                  ndelta.microseconds))
             ...     def decoder(tup):
             ...         return relativedelta(months=tup[0], days=tup[1],
-            ...                              seconds=tup[2],
-            ...                              microseconds=tup[3])
+            ...                              microseconds=tup[2])
             ...     await con.set_type_codec(
             ...         'interval', schema='pg_catalog', encoder=encoder,
             ...         decoder=decoder, format='tuple')

--- a/asyncpg/protocol/codecs/datetime.pyx
+++ b/asyncpg/protocol/codecs/datetime.pyx
@@ -339,21 +339,19 @@ cdef interval_encode_tuple(ConnectionSettings settings, WriteBuffer buf,
     cdef:
         int32_t months
         int32_t days
-        int64_t seconds
-        int32_t microseconds
+        int64_t microseconds
 
-    if len(obj) != 4:
+    if len(obj) != 3:
         raise ValueError(
-            'interval tuple encoder: expecting 4 elements '
+            'interval tuple encoder: expecting 3 elements '
             'in tuple, got {}'.format(len(obj)))
 
     months = obj[0]
     days = obj[1]
-    seconds = obj[2]
-    microseconds = obj[3]
+    microseconds = obj[2]
 
     buf.write_int32(16)
-    _encode_time(buf, seconds, microseconds)
+    buf.write_int64(microseconds)
     buf.write_int32(days)
     buf.write_int32(months)
 
@@ -385,14 +383,13 @@ cdef interval_decode_tuple(ConnectionSettings settings, FastReadBuffer buf):
     cdef:
         int32_t days
         int32_t months
-        int64_t seconds = 0
-        uint32_t microseconds = 0
+        int64_t microseconds
 
-    _decode_time(buf, &seconds, &microseconds)
+    microseconds = hton.unpack_int64(buf.read(8))
     days = hton.unpack_int32(buf.read(4))
     months = hton.unpack_int32(buf.read(4))
 
-    return (months, days, seconds, microseconds)
+    return (months, days, microseconds)
 
 
 cdef init_datetime_codecs():

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1014,7 +1014,7 @@ class TestCodecs(tb.ConnectedTestCase):
                 "tab.v AT TIME ZONE 'EST'"),
             ('timestamptz', (2**63 - 1,), 'infinity'),
             ('timestamptz', (-2**63,), '-infinity'),
-            ('interval', (2, 3, 0, 0), '2 mons 3 days')
+            ('interval', (2, 3, 1), '2 mons 3 days 00:00:00.000001')
         ]
 
         conn = await self.cluster.connect(database='postgres', loop=self.loop)


### PR DESCRIPTION
This makes interval consistent with other datetime types.