### PR TITLE
Fix `TypeError` on `get_attributes` when result has no columns

### DIFF
--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -37,6 +37,9 @@ cdef class PreparedStatementState:
     def _get_attributes(self):
         cdef Codec codec
 
+        if not self.row_desc:
+            return ()
+
         result = []
         for d in self.row_desc:
             name = d[0]

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1402,3 +1402,7 @@ class TestCodecs(tb.ConnectedTestCase):
                 DROP TABLE testtab;
                 DROP TYPE enum_t;
             ''')
+
+    async def test_no_result(self):
+        st = await self.con.prepare('rollback')
+        self.assertTupleEqual(st.get_attributes(), ())


### PR DESCRIPTION
Or it will raise:

```
  File "asyncpg/prepared_stmt.py", line 89, in get_attributes
    return self._state._get_attributes()
  File "asyncpg/protocol/prepared_stmt.pyx", line 41, in asyncpg.protocol.protocol.PreparedStatementState._get_attributes
TypeError: 'NoneType' object is not iterable
```