### PR TITLE
Do not attempt to connect to Unix sockets on Windows when host is not set

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -9,6 +9,7 @@ import asyncio
 import collections
 import getpass
 import os
+import platform
 import socket
 import struct
 import time
@@ -38,6 +39,9 @@ _ClientConfiguration = collections.namedtuple(
         'max_cached_statement_lifetime',
         'max_cacheable_statement_size',
     ])
+
+
+_system = platform.uname().system
 
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
@@ -123,9 +127,13 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
     if host is None:
         host = os.getenv('PGHOST')
         if not host:
-            host = ['/tmp', '/private/tmp',
-                    '/var/pgsql_socket', '/run/postgresql',
-                    'localhost']
+            if _system == 'Windows':
+                host = ['localhost']
+            else:
+                host = ['/tmp', '/private/tmp',
+                        '/var/pgsql_socket', '/run/postgresql',
+                        'localhost']
+
     if not isinstance(host, list):
         host = [host]
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -513,6 +513,12 @@ class TestConnection(tb.ConnectedTestCase):
                 loop=self.loop,
                 ssl=ssl_context)
 
+    async def test_connection_implicit_host(self):
+        conn_spec = self.cluster.get_connection_spec()
+        con = await asyncpg.connect(
+            port=conn_spec['port'], database='postgres', loop=self.loop)
+        await con.close()
+
 
 @unittest.skipIf(os.environ.get('PGHOST'), 'unmanaged cluster')
 class TestSSLConnection(tb.ConnectedTestCase):


### PR DESCRIPTION
When the host is not passed explicitly to `connect()`, asyncpg tries
to find a suitable socket in a few known directories.  On Windows, where
there are no file sockets, we should connect directly to 'localhost'
instead.

Fixes: #184.