### PR TITLE
Allow grabbing the version information programmatically.

### DIFF
--- a/.ci/package-version.py
+++ b/.ci/package-version.py
@@ -6,17 +6,17 @@ import sys
 
 
 def main():
-    setup_py = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                            'setup.py')
+    version_file = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                            'asyncpg', '__init__.py')
 
-    with open(setup_py, 'r') as f:
+    with open(version_file, 'r') as f:
         for line in f:
-            if line.startswith('VERSION ='):
+            if line.startswith('__version__ ='):
                 _, _, version = line.partition('=')
                 print(version.strip(" \n'\""))
                 return 0
 
-    print('could not find package version in setup.py', file=sys.stderr)
+    print('could not find package version in asyncpg/__init__.py', file=sys.stderr)
     return 1
 
 

--- a/asyncpg/__init__.py
+++ b/asyncpg/__init__.py
@@ -14,3 +14,5 @@ from .types import *  # NOQA
 
 __all__ = ('connect', 'create_pool', 'Record', 'Connection') + \
           exceptions.__all__  # NOQA
+
+__version__ = '0.12.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,18 +2,21 @@
 
 import alabaster
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.abspath('..'))
 
-with open(os.path.abspath('../setup.py'), 'rt') as f:
-    _m = re.search(
-        r'''VERSION\s*=\s*(?P<q>'|")(?P<ver>[\d\.]+)(?P=q)''', f.read())
-    if not _m:
-        raise RuntimeError('unable to read the version from setup.py')
-    version = _m.group('ver')
+version_file = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                            'asyncpg', '__init__.py')
 
+with open(version_file, 'r') as f:
+    for line in f:
+        if line.startswith('__version__ ='):
+            _, _, version = line.partition('=')
+            version = version.strip(" \n'\"")
+            break
+    else:
+        raise RuntimeError('unable to read the version from asyncpg/__init__.py')
 
 # -- General configuration ------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ from setuptools.command import build_ext as _build_ext
 if sys.version_info < (3, 5):
     raise RuntimeError('asyncpg requires Python 3.5 or greater')
 
-VERSION = '0.12.0'
 CFLAGS = ['-O2']
 LDFLAGS = []
 
@@ -179,6 +178,16 @@ class build_ext(_build_ext.build_ext):
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
     readme = f.read()
+
+
+with open(os.path.join(os.path.dirname(__file__), 'asyncpg', '__init__.py')) as f:
+    for line in f:
+        if line.startswith('__version__ ='):
+            _, _, version = line.partition('=')
+            VERSION = version.strip(" \n'\"")
+            break
+    else:
+        raise RuntimeError('unable to read the version from asyncpg/__init__.py')
 
 
 setuptools.setup(


### PR DESCRIPTION
Yes, we could use `pkg_resources`, but that imposes a serious slowdown, see [this issue](https://github.com/pypa/setuptools/issues/510) for context.