### PR TITLE
Fix issues with inet type I/O

### DIFF
--- a/asyncpg/protocol/codecs/network.pyx
+++ b/asyncpg/protocol/codecs/network.pyx
@@ -18,15 +18,37 @@ _ipaddr = ipaddress.ip_address
 _ipnet = ipaddress.ip_network
 
 
-cdef inline _net_encode(WriteBuffer buf, int32_t version, uint8_t bits,
+cdef inline uint8_t _ip_max_prefix_len(int32_t family):
+    # Maximum number of bits in the network prefix of the specified
+    # IP protocol version.
+    if family == PGSQL_AF_INET:
+        return 32
+    else:
+        return 128
+
+
+cdef inline int32_t _ip_addr_len(int32_t family):
+    # Length of address in bytes for the specified IP protocol version.
+    if family == PGSQL_AF_INET:
+        return 4
+    else:
+        return 16
+
+
+cdef inline int8_t _ver_to_family(int32_t version):
+    if version == 4:
+        return PGSQL_AF_INET
+    else:
+        return PGSQL_AF_INET6
+
+
+cdef inline _net_encode(WriteBuffer buf, int8_t family, uint32_t bits,
                         int8_t is_cidr, bytes addr):
 
     cdef:
         char *addrbytes
         ssize_t addrlen
-        int8_t family
 
-    family = PGSQL_AF_INET if version == 4 else PGSQL_AF_INET6
     cpython.PyBytes_AsStringAndSize(addr, &addrbytes, &addrlen)
 
     buf.write_int32(4 + <int32_t>addrlen)
@@ -41,28 +63,31 @@ cdef net_decode(ConnectionSettings settings, FastReadBuffer buf):
     cdef:
         int32_t family = <int32_t>buf.read(1)[0]
         uint8_t bits = <uint8_t>buf.read(1)[0]
-        uint32_t is_cidr = <uint32_t>buf.read(1)[0]
-        uint32_t addrlen = <uint32_t>buf.read(1)[0]
+        int32_t is_cidr = <int32_t>buf.read(1)[0]
+        int32_t addrlen = <int32_t>buf.read(1)[0]
         bytes addr
+        uint8_t max_prefix_len = _ip_max_prefix_len(family)
 
     if family != PGSQL_AF_INET and family != PGSQL_AF_INET6:
         raise ValueError('invalid address family in "{}" value'.format(
             'cidr' if is_cidr else 'inet'
         ))
 
-    if bits > (32 if family == PGSQL_AF_INET else 128):
-        raise ValueError('invalid bits in "{}" value'.format(
+    max_prefix_len = _ip_max_prefix_len(family)
+
+    if bits > max_prefix_len:
+        raise ValueError('invalid network prefix length in "{}" value'.format(
             'cidr' if is_cidr else 'inet'
         ))
 
-    if addrlen != (4 if family == PGSQL_AF_INET else 16):
-        raise ValueError('invalid length in "{}" value'.format(
+    if addrlen != _ip_addr_len(family):
+        raise ValueError('invalid address length in "{}" value'.format(
             'cidr' if is_cidr else 'inet'
         ))
 
     addr = cpython.PyBytes_FromStringAndSize(buf.read(addrlen), addrlen)
 
-    if is_cidr or bits > 0:
+    if is_cidr or bits != max_prefix_len:
         return _ipnet(addr).supernet(new_prefix=cpython.PyLong_FromLong(bits))
     else:
         return _ipaddr(addr)
@@ -71,15 +96,17 @@ cdef net_decode(ConnectionSettings settings, FastReadBuffer buf):
 cdef cidr_encode(ConnectionSettings settings, WriteBuffer buf, obj):
     cdef:
         object ipnet
+        int8_t family
 
     ipnet = _ipnet(obj)
-    _net_encode(buf, ipnet.version, ipnet.prefixlen, 1,
-                ipnet.network_address.packed)
+    family = _ver_to_family(ipnet.version)
+    _net_encode(buf, family, ipnet.prefixlen, 1, ipnet.network_address.packed)
 
 
 cdef inet_encode(ConnectionSettings settings, WriteBuffer buf, obj):
     cdef:
         object ipaddr
+        int8_t family
 
     try:
         ipaddr = _ipaddr(obj)
@@ -88,7 +115,8 @@ cdef inet_encode(ConnectionSettings settings, WriteBuffer buf, obj):
         # for the host datatype.
         cidr_encode(settings, buf, obj)
     else:
-        _net_encode(buf, ipaddr.version, 0, 0, ipaddr.packed)
+        family = _ver_to_family(ipaddr.version)
+        _net_encode(buf, family, _ip_max_prefix_len(family), 0, ipaddr.packed)
 
 
 cdef init_network_codecs():


### PR DESCRIPTION
The inet codec is confusing the network prefix length with the network
mask length, which causes incorrect wire encoding.  This was masked by a
symmetrical bug in the decoder.

Fixes #37.