### PR TITLE
Remove the deprecated "binary" parameter from Connection.set_type_codec

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -833,9 +833,6 @@ class Connection(metaclass=ConnectionMeta):
             Callable accepting a single argument encoded according to *format*
             and returning a decoded Python object.
 
-        :param binary:
-            **Deprecated**.  Use *format* instead.
-
         Example:
 
         .. code-block:: pycon
@@ -876,16 +873,11 @@ class Connection(metaclass=ConnectionMeta):
             The ``binary`` keyword argument is deprecated in favor of
             ``format``.
 
+        .. versionchanged:: 0.13.0
+            The ``binary`` keyword argument was removed in favor of
+            ``format``.
         """
         self._check_open()
-
-        if binary is not None:
-            format = 'binary' if binary else 'text'
-            warnings.warn(
-                "The `binary` keyword argument to "
-                "set_type_codec() is deprecated and will be removed in "
-                "asyncpg 0.13.0.  Use the `format` keyword argument instead.",
-                DeprecationWarning, stacklevel=2)
 
         typeinfo = await self.fetchrow(
             introspection.TYPE_BY_NAME, typename, schema)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1129,30 +1129,6 @@ class TestCodecs(tb.ConnectedTestCase):
         finally:
             await conn.close()
 
-    async def test_custom_codec_override_deprecation(self):
-        conn = await self.cluster.connect(database='postgres', loop=self.loop)
-        try:
-            def _encoder(value):
-                return value
-
-            def _decoder(value):
-                return value
-
-            with self.assertWarnsRegex(DeprecationWarning,
-                                       r"The `binary` keyword argument to "
-                                       r"set_type_codec\(\) is deprecated"):
-                await conn.set_type_codec(
-                    'uuid', encoder=_encoder, decoder=_decoder,
-                    schema='pg_catalog', binary=False
-                )
-
-                data = '14058ad9-0118-4b7e-ac15-01bc13e2ccd1'
-                res = await conn.fetchval('SELECT $1::uuid', data)
-                self.assertEqual(res, data)
-
-        finally:
-            await conn.close()
-
     async def test_composites_in_arrays(self):
         await self.con.execute('''
             CREATE TYPE t AS (a text, b int);


### PR DESCRIPTION
set_type_codec(..., binary=True) was deprecated in 0.12.0.