### PR TITLE
Support timeouts in Connection.close() and Pool.release()

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
     - "%PYTHON% setup.py build_ext --inplace"
 
 test_script:
-    - "%PYTHON% -m unittest discover -s tests"
+    - "%PYTHON% setup.py test"
 
 after_test:
     - "%PYTHON% setup.py bdist_wheel"

--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -26,7 +26,7 @@ branches:
 
 install:
     - "%PYTHON% -m pip install --upgrade pip wheel setuptools"
-    - "%PYTHON% -m pip install -r .ci/requirements-win.txt"
+    - "%PYTHON% -m pip install --upgrade -r .ci/requirements-win.txt"
 
 build_script:
     - "%PYTHON% setup.py build_ext --inplace"

--- a/.ci/requirements-win.txt
+++ b/.ci/requirements-win.txt
@@ -1,2 +1,2 @@
-cython>=0.24
+cython>=0.27.2
 tinys3

--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -1,5 +1,5 @@
-cython>=0.24
+cython>=0.27.2
 flake8>=3.4.1
-uvloop>=0.5.0
+uvloop>=0.8.0
 tinys3
 twine

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -10,4 +10,4 @@ fi
 
 pip install --upgrade pip wheel
 pip install --upgrade setuptools
-pip install -r .ci/requirements.txt
+pip install --upgrade -r .ci/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.ymlc~
 *.scssc
 *.so
+*.pyd
 *~
 .#*
 .DS_Store

--- a/asyncpg/_testbase/fuzzer.py
+++ b/asyncpg/_testbase/fuzzer.py
@@ -1,0 +1,295 @@
+# Copyright (C) 2016-present the asyncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+
+import asyncio
+import socket
+import threading
+import typing
+
+from asyncpg import cluster
+
+
+class StopServer(Exception):
+    pass
+
+
+class TCPFuzzingProxy:
+    def __init__(self, *, listening_addr: str='127.0.0.1',
+                 listening_port: typing.Optional[int]=None,
+                 backend_host: str, backend_port: int,
+                 settings: typing.Optional[dict]=None) -> None:
+        self.listening_addr = listening_addr
+        self.listening_port = listening_port
+        self.backend_host = backend_host
+        self.backend_port = backend_port
+        self.settings = settings or {}
+        self.loop = None
+        self.connectivity = None
+        self.connectivity_loss = None
+        self.stop_event = None
+        self.connections = {}
+        self.sock = None
+        self.listen_task = None
+
+    async def _wait(self, work):
+        work_task = asyncio.ensure_future(work, loop=self.loop)
+        stop_event_task = asyncio.ensure_future(self.stop_event.wait(),
+                                                loop=self.loop)
+
+        try:
+            await asyncio.wait(
+                [work_task, stop_event_task],
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self.loop)
+
+            if self.stop_event.is_set():
+                raise StopServer()
+            else:
+                return work_task.result()
+        finally:
+            if not work_task.done():
+                work_task.cancel()
+            if not stop_event_task.done():
+                stop_event_task.cancel()
+
+    def start(self):
+        started = threading.Event()
+        self.thread = threading.Thread(target=self._start, args=(started,))
+        self.thread.start()
+        if not started.wait(timeout=2):
+            raise RuntimeError('fuzzer proxy failed to start')
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self._stop)
+        self.thread.join()
+
+    def _stop(self):
+        self.stop_event.set()
+
+    def _start(self, started_event):
+        self.loop = asyncio.new_event_loop()
+
+        self.connectivity = asyncio.Event(loop=self.loop)
+        self.connectivity.set()
+        self.connectivity_loss = asyncio.Event(loop=self.loop)
+        self.stop_event = asyncio.Event(loop=self.loop)
+
+        if self.listening_port is None:
+            self.listening_port = cluster.find_available_port()
+
+        self.sock = socket.socket()
+        self.sock.bind((self.listening_addr, self.listening_port))
+        self.sock.listen(50)
+        self.sock.setblocking(False)
+
+        try:
+            self.loop.run_until_complete(self._main(started_event))
+        finally:
+            self.loop.close()
+
+    async def _main(self, started_event):
+        self.listen_task = asyncio.ensure_future(self.listen(), loop=self.loop)
+        # Notify the main thread that we are ready to go.
+        started_event.set()
+        try:
+            await self.listen_task
+        finally:
+            for c in list(self.connections):
+                c.close()
+            await asyncio.sleep(0.01, loop=self.loop)
+            if hasattr(self.loop, 'remove_reader'):
+                self.loop.remove_reader(self.sock.fileno())
+            self.sock.close()
+
+    async def listen(self):
+        while True:
+            try:
+                client_sock, _ = await self._wait(
+                    self.loop.sock_accept(self.sock))
+
+                backend_sock = socket.socket()
+                backend_sock.setblocking(False)
+
+                await self._wait(self.loop.sock_connect(
+                    backend_sock, (self.backend_host, self.backend_port)))
+            except StopServer:
+                break
+
+            conn = Connection(client_sock, backend_sock, self)
+            conn_task = self.loop.create_task(conn.handle())
+            self.connections[conn] = conn_task
+
+    def trigger_connectivity_loss(self):
+        self.loop.call_soon_threadsafe(self._trigger_connectivity_loss)
+
+    def _trigger_connectivity_loss(self):
+        self.connectivity.clear()
+        self.connectivity_loss.set()
+
+    def restore_connectivity(self):
+        self.loop.call_soon_threadsafe(self._restore_connectivity)
+
+    def _restore_connectivity(self):
+        self.connectivity.set()
+        self.connectivity_loss.clear()
+
+    def reset(self):
+        self.restore_connectivity()
+
+    def _close_connection(self, connection):
+        conn_task = self.connections.pop(connection, None)
+        if conn_task is not None:
+            conn_task.cancel()
+
+
+class Connection:
+    def __init__(self, client_sock, backend_sock, proxy):
+        self.client_sock = client_sock
+        self.backend_sock = backend_sock
+        self.proxy = proxy
+        self.loop = proxy.loop
+        self.connectivity = proxy.connectivity
+        self.connectivity_loss = proxy.connectivity_loss
+        self.proxy_to_backend_task = None
+        self.proxy_from_backend_task = None
+        self.is_closed = False
+
+    def close(self):
+        if self.is_closed:
+            return
+
+        self.is_closed = True
+
+        if self.proxy_to_backend_task is not None:
+            self.proxy_to_backend_task.cancel()
+            self.proxy_to_backend_task = None
+
+        if self.proxy_from_backend_task is not None:
+            self.proxy_from_backend_task.cancel()
+            self.proxy_from_backend_task = None
+
+        self.proxy._close_connection(self)
+
+    async def handle(self):
+        self.proxy_to_backend_task = asyncio.ensure_future(
+            self.proxy_to_backend(), loop=self.loop)
+
+        self.proxy_from_backend_task = asyncio.ensure_future(
+            self.proxy_from_backend(), loop=self.loop)
+
+        try:
+            await asyncio.wait(
+                [self.proxy_to_backend_task, self.proxy_from_backend_task],
+                loop=self.loop, return_when=asyncio.FIRST_COMPLETED)
+
+        finally:
+            if hasattr(self.loop, 'remove_reader'):
+                # Asyncio *really* doesn't like when the sockets are
+                # closed under it.
+                self.loop.remove_reader(self.client_sock.fileno())
+                self.loop.remove_writer(self.client_sock.fileno())
+                self.loop.remove_reader(self.backend_sock.fileno())
+                self.loop.remove_writer(self.backend_sock.fileno())
+
+            self.client_sock.close()
+            self.backend_sock.close()
+
+    async def _read(self, sock, n):
+        read_task = asyncio.ensure_future(
+            self.loop.sock_recv(sock, n),
+            loop=self.loop)
+        conn_event_task = asyncio.ensure_future(
+            self.connectivity_loss.wait(),
+            loop=self.loop)
+
+        try:
+            await asyncio.wait(
+                [read_task, conn_event_task],
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self.loop)
+
+            if self.connectivity_loss.is_set():
+                return None
+            else:
+                return read_task.result()
+        finally:
+            if not read_task.done():
+                read_task.cancel()
+            if not conn_event_task.done():
+                conn_event_task.cancel()
+
+    async def _write(self, sock, data):
+        write_task = asyncio.ensure_future(
+            self.loop.sock_sendall(sock, data), loop=self.loop)
+        conn_event_task = asyncio.ensure_future(
+            self.connectivity_loss.wait(), loop=self.loop)
+
+        try:
+            await asyncio.wait(
+                [write_task, conn_event_task],
+                return_when=asyncio.FIRST_COMPLETED,
+                loop=self.loop)
+
+            if self.connectivity_loss.is_set():
+                return None
+            else:
+                return write_task.result()
+        finally:
+            if not write_task.done():
+                write_task.cancel()
+            if not conn_event_task.done():
+                conn_event_task.cancel()
+
+    async def proxy_to_backend(self):
+        buf = None
+
+        try:
+            while True:
+                await self.connectivity.wait()
+                if buf is not None:
+                    data = buf
+                    buf = None
+                else:
+                    data = await self._read(self.client_sock, 4096)
+                if data == b'':
+                    break
+                if self.connectivity_loss.is_set():
+                    if data:
+                        buf = data
+                    continue
+                await self._write(self.backend_sock, data)
+
+        except ConnectionError:
+            pass
+
+        finally:
+            self.loop.call_soon(self.close)
+
+    async def proxy_from_backend(self):
+        buf = None
+
+        try:
+            while True:
+                await self.connectivity.wait()
+                if buf is not None:
+                    data = buf
+                    buf = None
+                else:
+                    data = await self._read(self.backend_sock, 4096)
+                if data == b'':
+                    break
+                if self.connectivity_loss.is_set():
+                    if data:
+                        buf = data
+                    continue
+                await self._write(self.client_sock, data)
+
+        except ConnectionError:
+            pass
+
+        finally:
+            self.loop.call_soon(self.close)

--- a/asyncpg/cluster.py
+++ b/asyncpg/cluster.py
@@ -448,6 +448,7 @@ class Cluster:
                 try:
                     con = loop.run_until_complete(
                         asyncpg.connect(database='postgres',
+                                        user='postgres',
                                         timeout=5, loop=loop,
                                         **self._connection_addr))
                 except (OSError, asyncio.TimeoutError,

--- a/tests/test_adversity.py
+++ b/tests/test_adversity.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2016-present the asyncpg authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of asyncpg and is released under
+# the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests how asyncpg behaves in non-ideal conditions."""
+
+import asyncio
+import os
+import unittest
+
+from asyncpg import _testbase as tb
+
+
+@unittest.skipIf(os.environ.get('PGHOST'), 'using remote cluster for testing')
+class TestConnectionLoss(tb.ProxiedClusterTestCase):
+    @tb.with_timeout(30.0)
+    async def test_connection_close_timeout(self):
+        con = await self.connect()
+        self.proxy.trigger_connectivity_loss()
+        with self.assertRaises(asyncio.TimeoutError):
+            await con.close(timeout=0.5)
+
+    @tb.with_timeout(30.0)
+    async def test_pool_release_timeout(self):
+        pool = await self.create_pool(
+            database='postgres', min_size=2, max_size=2)
+        try:
+            with self.assertRaises(asyncio.TimeoutError):
+                async with pool.acquire(timeout=0.5):
+                    self.proxy.trigger_connectivity_loss()
+        finally:
+            self.proxy.restore_connectivity()
+            await pool.close()
+
+    @tb.with_timeout(30.0)
+    async def test_pool_handles_abrupt_connection_loss(self):
+        pool_size = 3
+        query_runtime = 0.5
+        pool_timeout = cmd_timeout = 1.0
+        concurrency = 9
+        pool_concurrency = (concurrency - 1) // pool_size + 1
+
+        # Worst expected runtime + 20% to account for other latencies.
+        worst_runtime = (pool_timeout + cmd_timeout) * pool_concurrency * 1.2
+
+        async def worker(pool):
+            async with pool.acquire(timeout=pool_timeout) as con:
+                await con.fetch('SELECT pg_sleep($1)', query_runtime)
+
+        def kill_connectivity():
+            self.proxy.trigger_connectivity_loss()
+
+        new_pool = self.create_pool(
+            database='postgres', min_size=pool_size, max_size=pool_size,
+            timeout=cmd_timeout, command_timeout=cmd_timeout)
+
+        with self.assertRunUnder(worst_runtime):
+            async with new_pool as pool:
+                workers = [worker(pool) for _ in range(concurrency)]
+                self.loop.call_later(1, kill_connectivity)
+                await asyncio.gather(
+                    *workers, loop=self.loop, return_exceptions=True)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1011,7 +1011,7 @@ class TestCodecs(tb.ConnectedTestCase):
         """Test overriding core codecs."""
         import json
 
-        conn = await self.cluster.connect(database='postgres', loop=self.loop)
+        conn = await self.connect()
         try:
             def _encoder(value):
                 return json.dumps(value).encode('utf-8')
@@ -1035,7 +1035,7 @@ class TestCodecs(tb.ConnectedTestCase):
         """Test overriding core codecs."""
         import json
 
-        conn = await self.cluster.connect(database='postgres', loop=self.loop)
+        conn = await self.connect()
         try:
             def _encoder(value):
                 return json.dumps(value)
@@ -1087,7 +1087,7 @@ class TestCodecs(tb.ConnectedTestCase):
             ('interval', (2, 3, 1), '2 mons 3 days 00:00:00.000001')
         ]
 
-        conn = await self.cluster.connect(database='postgres', loop=self.loop)
+        conn = await self.connect()
 
         def _encoder(value):
             return tuple(value)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -78,8 +78,7 @@ class TestExecuteScript(tb.ConnectedTestCase):
         await self.con.close()
         self.assertTrue(self.con.is_closed())
 
-        with self.assertRaisesRegex(asyncpg.ConnectionDoesNotExistError,
-                                    'closed in the middle'):
+        with self.assertRaises(asyncpg.QueryCanceledError):
             await fut
 
     async def test_execute_script_interrupted_terminate(self):

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -16,8 +16,7 @@ class TestIntrospection(tb.ConnectedTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.adminconn = cls.loop.run_until_complete(
-            cls.cluster.connect(database='postgres', loop=cls.loop))
+        cls.adminconn = cls.loop.run_until_complete(cls.connect())
         cls.loop.run_until_complete(
             cls.adminconn.execute('CREATE DATABASE asyncpg_intro_test'))
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -656,7 +656,8 @@ class TestHotStandby(tb.ConnectedTestCase):
 
         try:
             con = cls.loop.run_until_complete(
-                cls.master_cluster.connect(database='postgres', loop=cls.loop))
+                cls.master_cluster.connect(
+                    database='postgres', user='postgres', loop=cls.loop))
 
             cls.loop.run_until_complete(
                 con.execute('''
@@ -696,8 +697,9 @@ class TestHotStandby(tb.ConnectedTestCase):
     async def test_standby_pool_01(self):
         for n in {1, 3, 5, 10, 20, 100}:
             with self.subTest(tasksnum=n):
-                pool = await self.create_pool(database='postgres',
-                                              min_size=5, max_size=10)
+                pool = await self.create_pool(
+                    database='postgres', user='postgres',
+                    min_size=5, max_size=10)
 
                 async def worker():
                     con = await pool.acquire()
@@ -710,7 +712,7 @@ class TestHotStandby(tb.ConnectedTestCase):
 
     async def test_standby_cursors(self):
         con = await self.standby_cluster.connect(
-            database='postgres', loop=self.loop)
+            database='postgres', user='postgres', loop=self.loop)
 
         try:
             async with con.transaction():

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -94,8 +94,7 @@ class TestPrepare(tb.ConnectedTestCase):
         await self.con.close()
         self.assertTrue(self.con.is_closed())
 
-        with self.assertRaisesRegex(asyncpg.ConnectionDoesNotExistError,
-                                    'closed in the middle'):
+        with self.assertRaises(asyncpg.QueryCanceledError):
             await fut
 
         # Test that it's OK to call close again

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -114,9 +114,7 @@ class TestTimeout(tb.ConnectedTestCase):
             with self.subTest(command_timeout=command_timeout):
                 with self.assertRaisesRegex(ValueError,
                                             'invalid command_timeout'):
-                    await self.cluster.connect(
-                        database='postgres', loop=self.loop,
-                        command_timeout=command_timeout)
+                    await self.connect(command_timeout=command_timeout)
 
         # Note: negative timeouts are OK for method calls.
         for methname in {'fetch', 'fetchrow', 'fetchval', 'execute'}:


### PR DESCRIPTION
`Connection.close()` and `Pool.release()` each gained the new `timeout`
parameter.  The `pool.acquire()` context manager now applies the
passed timeout to `__aexit__()` as well.

`Connection.close()` is now actually graceful.  Instead of simply dropping
the connection, it attempts to cancel the running query (if any), asks
the server to terminate the connection and waits for the connection to
terminate.

To test all this properly, implement a TCP proxy, which emulates sudden
connectivity loss (i.e. packets not reaching the server).

Closes: #220