### PR TITLE
Add CrateDB detection

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1583,6 +1583,13 @@ def _detect_server_capabilities(server_version, connection_settings):
         plpgsql = False
         sql_reset = False
         sql_close_all = False
+    elif hasattr(connection_settings, 'crate_version'):
+        # CrateDB detected.
+        advisory_locks = False
+        notifications = False
+        plpgsql = False
+        sql_reset = False
+        sql_close_all = False
     else:
         # Standard PostgreSQL server assumed.
         advisory_locks = True


### PR DESCRIPTION
To support connection pooling if used with
https://github.com/crate/crate

This depends on https://github.com/crate/crate/pull/6476
(So this will only work starting with CrateDB 2.3)

ParameterDescription support in CrateDB is also a bit limited - so certain queries might still not work.