### PR TITLE
Fix issues with timetz type I/O

### DIFF
--- a/asyncpg/serverversion.py
+++ b/asyncpg/serverversion.py
@@ -34,6 +34,15 @@ def split_server_version_string(version_string):
         level = 'final'
         serial = 0
 
+    if int(parts[0]) >= 10:
+        # Since PostgreSQL 10 the versioning scheme has changed.
+        # 10.x really means 10.0.x.  While parsing 10.1
+        # as (10, 1) may seem less confusing, in practice most
+        # version checks are written as version[:2], and we
+        # want to keep that behaviour consistent, i.e not fail
+        # a major version check due to a bugfix release.
+        parts.insert(1, 0)
+
     versions = [int(p) for p in parts][:3]
     if len(versions) < 3:
         versions += [0] * (3 - len(versions))

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -53,11 +53,10 @@ class TestSettings(tb.ConnectedTestCase):
             ("9.4beta1", (9, 4, 0, 'beta', 1),),
             ("10devel", (10, 0, 0, 'devel', 0),),
             ("10beta2", (10, 0, 0, 'beta', 2),),
-
-            # Despite the fact after version 10 Postgre's second number
-            # means "micro", it is parsed "as is" to be
-            # less confusing in comparisons.
-            ("10.1", (10, 1, 0, 'final', 0),),
+            # For PostgreSQL versions >=10 we always
+            # set version.minor to 0.
+            ("10.1", (10, 0, 1, 'final', 0),),
+            ("11.1.2", (11, 0, 1, 'final', 0),),
         ]
         for version, expected in versions:
             result = split_server_version_string(version)


### PR DESCRIPTION
For timetz an offset is applied to a time itself, it is not a time zone offset.
This was masked by a symmetrical bug in the encoder.

An offset value is still passed in a tuple (timetz_decode_tuple) as it was
received from Postgres.