### PR TITLE
Guard transaction methods against underlying connection release

### DIFF
--- a/asyncpg/connresource.py
+++ b/asyncpg/connresource.py
@@ -36,3 +36,9 @@ class ConnectionResource:
                 'cannot call {}.{}(): '
                 'the underlying connection has been released back '
                 'to the pool'.format(self.__class__.__name__, meth_name))
+
+        if self._connection.is_closed():
+            raise exceptions.InterfaceError(
+                'cannot call {}.{}(): '
+                'the underlying connection is closed'.format(
+                    self.__class__.__name__, meth_name))


### PR DESCRIPTION
Similarly to other connection-dependent objects, transaction methods
should not be called once the underlying connection has been released to
the pool.

Also, add a special handling for the case of asynchronous generator
finalization, in which case it's OK for `Transaction.__aexit__()` to be
called _after_ `Pool.release()`, since we cannot control when the
finalization task would execute.

Fixes: #232.