### PR TITLE
Invalidate type cache on schema changes affecting statement result.

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -423,6 +423,7 @@ class Connection(metaclass=ConnectionMeta):
             ...         'mytable', columns=('foo', 'bar'),
             ...         output='file.csv', format='csv')
             ...     print(result)
+            ...
             >>> asyncio.get_event_loop().run_until_complete(run())
             'COPY 100'
 
@@ -491,6 +492,7 @@ class Connection(metaclass=ConnectionMeta):
             ...         'SELECT foo, bar FROM mytable WHERE foo > $1', 10,
             ...         output='file.csv', format='csv')
             ...     print(result)
+            ...
             >>> asyncio.get_event_loop().run_until_complete(run())
             'COPY 10'
 
@@ -556,7 +558,8 @@ class Connection(metaclass=ConnectionMeta):
             ...     con = await asyncpg.connect(user='postgres')
             ...     result = await con.copy_to_table(
             ...         'mytable', source='datafile.tbl')
-            ....    print(result)
+            ...     print(result)
+            ...
             >>> asyncio.get_event_loop().run_until_complete(run())
             'COPY 140000'
 
@@ -621,7 +624,8 @@ class Connection(metaclass=ConnectionMeta):
             ...         'mytable', records=[
             ...             (1, 'foo', 'bar'),
             ...             (2, 'ham', 'spam')])
-            ....    print(result)
+            ...     print(result)
+            ...
             >>> asyncio.get_event_loop().run_until_complete(run())
             'COPY 2'
 
@@ -861,6 +865,7 @@ class Connection(metaclass=ConnectionMeta):
             ...         "SELECT '2 years 3 mons 1 day'::interval")
             ...     print(result)
             ...     print(datetime.datetime(2002, 1, 1) + result)
+            ...
             >>> asyncio.get_event_loop().run_until_complete(run())
             relativedelta(years=+2, months=+3, days=+1)
             2004-04-02 00:00:00
@@ -1399,6 +1404,7 @@ async def connect(dsn=None, *,
         ...     con = await asyncpg.connect(user='postgres')
         ...     types = await con.fetch('SELECT * FROM pg_type')
         ...     print(types)
+        ...
         >>> asyncio.get_event_loop().run_until_complete(run())
         [<Record typname='bool' typnamespace=11 ...
 

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -12,7 +12,7 @@ import textwrap
 
 __all__ = ('PostgresError', 'FatalPostgresError', 'UnknownPostgresError',
            'InterfaceError', 'InterfaceWarning', 'PostgresLogMessage',
-           'InternalClientError')
+           'InternalClientError', 'OutdatedSchemaCacheError')
 
 
 def _is_asyncpg_class(cls):
@@ -219,6 +219,16 @@ class InterfaceWarning(InterfaceMessage, UserWarning):
 
 class InternalClientError(Exception):
     pass
+
+
+class OutdatedSchemaCacheError(InternalClientError):
+    """A value decoding error caused by a schema change before row fetching."""
+
+    def __init__(self, msg, *, schema=None, data_type=None, position=None):
+        super().__init__(msg)
+        self.schema_name = schema
+        self.data_type_name = data_type
+        self.position = position
 
 
 class PostgresLogMessage(PostgresMessage):

--- a/asyncpg/protocol/settings.pxd
+++ b/asyncpg/protocol/settings.pxd
@@ -22,6 +22,7 @@ cdef class ConnectionSettings:
         decoder, format)
     cpdef inline remove_python_codec(
         self, typeoid, typename, typeschema)
+    cpdef inline clear_type_cache(self)
     cpdef inline set_builtin_type_codec(
         self, typeoid, typename, typeschema, typekind, alias_to)
     cpdef inline Codec get_data_codec(self, uint32_t oid, ServerDataFormat format=*)

--- a/asyncpg/protocol/settings.pyx
+++ b/asyncpg/protocol/settings.pyx
@@ -60,6 +60,9 @@ cdef class ConnectionSettings:
     cpdef inline remove_python_codec(self, typeoid, typename, typeschema):
         self._data_codecs.remove_python_codec(typeoid, typename, typeschema)
 
+    cpdef inline clear_type_cache(self):
+        self._data_codecs.clear_type_cache()
+
     cpdef inline set_builtin_type_codec(self, typeoid, typename, typeschema,
                                         typekind, alias_to):
         self._data_codecs.set_builtin_type_codec(typeoid, typename, typeschema,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class build_ext(_build_ext.build_ext):
         ('cython-annotate', None,
             'Produce a colorized HTML version of the Cython source.'),
         ('cython-directives=', None,
-            'Cythion compiler directives'),
+            'Cython compiler directives'),
     ]
 
     def initialize_options(self):

--- a/tests/test_cache_invalidation.py
+++ b/tests/test_cache_invalidation.py
@@ -8,6 +8,9 @@
 import asyncpg
 from asyncpg import _testbase as tb
 
+ERRNUM = 'unexpected number of attributes of composite type'
+ERRTYP = 'unexpected data type of composite type'
+
 
 class TestCacheInvalidation(tb.ConnectedTestCase):
     async def test_prepare_cache_invalidation_silent(self):
@@ -83,3 +86,220 @@ class TestCacheInvalidation(tb.ConnectedTestCase):
         finally:
             await self.con.execute('DROP TABLE tab1')
             await pool.close()
+
+    async def test_type_cache_invalidation_in_transaction(self):
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            async with self.con.transaction():
+                await self.con.execute('ALTER TYPE typ1 ADD ATTRIBUTE c text')
+                with self.assertRaisesRegex(
+                        asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                    await self.con.fetchrow('SELECT * FROM tab1')
+                # The second request must be correct (cache was dropped):
+                result = await self.con.fetchrow('SELECT * FROM tab1')
+                self.assertEqual(result, (1, (2, 3, None)))
+
+            # This is now OK, the cache is actual after the transaction.
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3, None)))
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+
+    async def test_type_cache_invalidation_in_cancelled_transaction(self):
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            try:
+                async with self.con.transaction():
+                    await self.con.execute(
+                        'ALTER TYPE typ1 ADD ATTRIBUTE c text')
+                    with self.assertRaisesRegex(
+                            asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                        await self.con.fetchrow('SELECT * FROM tab1')
+                    # The second request must be correct (cache was dropped):
+                    result = await self.con.fetchrow('SELECT * FROM tab1')
+                    self.assertEqual(result, (1, (2, 3, None)))
+                    raise UserWarning  # Just to generate ROLLBACK
+            except UserWarning:
+                pass
+
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                await self.con.fetchrow('SELECT * FROM tab1')
+            # This is now OK, the cache is filled after being dropped.
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+
+    async def test_prepared_type_cache_invalidation(self):
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+            prep = await self.con.prepare('SELECT * FROM tab1')
+            result = await prep.fetchrow()
+            self.assertEqual(result, (1, (2, 3)))
+
+            try:
+                async with self.con.transaction():
+                    await self.con.execute(
+                        'ALTER TYPE typ1 ADD ATTRIBUTE c text')
+                    with self.assertRaisesRegex(
+                            asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                        await prep.fetchrow()
+                    # PS has its local cache for types codecs, even after the
+                    # cache cleanup it is not possible to use it.
+                    # That's why it is marked as closed.
+                    with self.assertRaisesRegex(
+                            asyncpg.InterfaceError,
+                            'the prepared statement is closed'):
+                        await prep.fetchrow()
+
+                    prep = await self.con.prepare('SELECT * FROM tab1')
+                    # The second PS must be correct (cache was dropped):
+                    result = await prep.fetchrow()
+                    self.assertEqual(result, (1, (2, 3, None)))
+                    raise UserWarning  # Just to generate ROLLBACK
+            except UserWarning:
+                pass
+
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                await prep.fetchrow()
+
+            # Reprepare it again after dropping cache.
+            prep = await self.con.prepare('SELECT * FROM tab1')
+            # This is now OK, the cache is filled after being dropped.
+            result = await prep.fetchrow()
+            self.assertEqual(result, (1, (2, 3)))
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+
+    async def test_type_cache_invalidation_on_drop_type_attr(self):
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int, c text)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute(
+                'INSERT INTO tab1 VALUES (1, (2, 3, $1))', 'x')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3, 'x')))
+
+            await self.con.execute('ALTER TYPE typ1 DROP ATTRIBUTE x')
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                await self.con.fetchrow('SELECT * FROM tab1')
+
+            # This is now OK, the cache is filled after being dropped.
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (3, 'x')))
+
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+
+    async def test_type_cache_invalidation_on_change_attr(self):
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            # It is slightly artificial, but can take place in transactional
+            # schema changing. Nevertheless, if the code checks and raises it
+            # the most probable reason is a difference with the cache type.
+            await self.con.execute('ALTER TYPE typ1 DROP ATTRIBUTE y')
+            await self.con.execute('ALTER TYPE typ1 ADD ATTRIBUTE y bigint')
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRTYP):
+                await self.con.fetchrow('SELECT * FROM tab1')
+
+            # This is now OK, the cache is filled after being dropped.
+            result = await self.con.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, None)))
+
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+
+    async def test_type_cache_invalidation_in_pool(self):
+        await self.con.execute('CREATE DATABASE testdb')
+        pool = await self.create_pool(database='postgres',
+                                      min_size=2, max_size=2)
+
+        pool_chk = await self.create_pool(database='testdb',
+                                          min_size=2, max_size=2)
+
+        await self.con.execute('CREATE TYPE typ1 AS (x int, y int)')
+        await self.con.execute('CREATE TABLE tab1(a int, b typ1)')
+
+        try:
+            await self.con.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+
+            con1 = await pool.acquire()
+            con2 = await pool.acquire()
+
+            result = await con1.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            result = await con2.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            # Create the same schema in the "testdb", fetch data which caches
+            # type info.
+            con_chk = await pool_chk.acquire()
+            await con_chk.execute('CREATE TYPE typ1 AS (x int, y int)')
+            await con_chk.execute('CREATE TABLE tab1(a int, b typ1)')
+            await con_chk.execute('INSERT INTO tab1 VALUES (1, (2, 3))')
+            result = await con_chk.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3)))
+
+            # Change schema in the databases.
+            await self.con.execute('ALTER TYPE typ1 ADD ATTRIBUTE c text')
+            await con_chk.execute('ALTER TYPE typ1 ADD ATTRIBUTE c text')
+
+            # con1 tries to get cached type info, fails, but invalidates the
+            # cache for the entire pool.
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                await con1.fetchrow('SELECT * FROM tab1')
+
+            async with con2.transaction():
+                # This should work, as con1 should have invalidated all caches.
+                result = await con2.fetchrow('SELECT * FROM tab1')
+                self.assertEqual(result, (1, (2, 3, None)))
+
+            # After all the con1 uses actual info from renewed cache entry.
+            result = await con1.fetchrow('SELECT * FROM tab1')
+            self.assertEqual(result, (1, (2, 3, None)))
+
+            # Check the invalidation is database-specific, i.e. cache entries
+            # for pool_chk/con_chk was not dropped via pool/con1.
+            with self.assertRaisesRegex(
+                    asyncpg.OutdatedSchemaCacheError, ERRNUM):
+                await con_chk.fetchrow('SELECT * FROM tab1')
+
+        finally:
+            await self.con.execute('DROP TABLE tab1')
+            await self.con.execute('DROP TYPE typ1')
+            await pool.close()
+            await pool_chk.close()
+            await self.con.execute('DROP DATABASE testdb')


### PR DESCRIPTION
Almost all explanation is written in the commit message.

The rest I want to mention is at least one feature is left untouched. It is the `BaseCursor` where the `bind_execute` and `bind` calls should be wrapped by the same way the `bind_execute` in the `PreparedStatement.__bind_execute` was, but I'd leave it for the other commit (may be by the other author).