### PR TITLE
Initialize statement codecs immediately after Prepare

### DIFF
--- a/asyncpg/protocol/prepared_stmt.pxd
+++ b/asyncpg/protocol/prepared_stmt.pxd
@@ -30,6 +30,7 @@ cdef class PreparedStatementState:
         tuple        rows_codecs
 
     cdef _encode_bind_msg(self, args)
+    cpdef _init_codecs(self)
     cdef _ensure_rows_decoder(self)
     cdef _ensure_args_encoder(self)
     cdef _set_row_desc(self, object desc)

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -82,6 +82,10 @@ cdef class PreparedStatementState:
         else:
             return True
 
+    cpdef _init_codecs(self):
+        self._ensure_args_encoder()
+        self._ensure_rows_decoder()
+
     def attach(self):
         self.refs += 1
 
@@ -100,9 +104,6 @@ cdef class PreparedStatementState:
         if len(args) > 32767:
             raise exceptions.InterfaceError(
                 'the number of query arguments cannot exceed 32767')
-
-        self._ensure_args_encoder()
-        self._ensure_rows_decoder()
 
         writer = WriteBuffer.new()
 

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -146,7 +146,8 @@ cdef class BaseProtocol(CoreProtocol):
             self.is_reading = False
             self.transport.pause_reading()
 
-    async def prepare(self, stmt_name, query, timeout):
+    async def prepare(self, stmt_name, query, timeout,
+                      PreparedStatementState state=None):
         if self.cancel_waiter is not None:
             await self.cancel_waiter
         if self.cancel_sent_waiter is not None:
@@ -160,7 +161,9 @@ cdef class BaseProtocol(CoreProtocol):
         try:
             self._prepare(stmt_name, query)  # network op
             self.last_query = query
-            self.statement = PreparedStatementState(stmt_name, query, self)
+            if state is None:
+                state = PreparedStatementState(stmt_name, query, self)
+            self.statement = state
         except Exception as ex:
             waiter.set_exception(ex)
             self._coreproto_error()


### PR DESCRIPTION
Currently the statement codecs are populated just before the first Bind
is issued.  This is problematic as in the time since Prepare, the codec
cache for derived types (arrays, composites etc.) may have been purged
by an installation of a custom codec, or general schema state
invalidation.

Fix this by populating the codecs immediately after the statement data
types have been resolved.

Fixes: #241.