### PR TITLE
Adds consecutive exception tracker to connections

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -38,6 +38,7 @@ _ClientConfiguration = collections.namedtuple(
         'statement_cache_size',
         'max_cached_statement_lifetime',
         'max_cacheable_statement_size',
+        'max_consecutive_exceptions',
     ])
 
 
@@ -210,6 +211,7 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, database,
                              timeout, command_timeout, statement_cache_size,
                              max_cached_statement_lifetime,
                              max_cacheable_statement_size,
+                             max_consecutive_exceptions,
                              ssl, server_settings):
 
     local_vars = locals()
@@ -245,7 +247,8 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, database,
         command_timeout=command_timeout,
         statement_cache_size=statement_cache_size,
         max_cached_statement_lifetime=max_cached_statement_lifetime,
-        max_cacheable_statement_size=max_cacheable_statement_size,)
+        max_cacheable_statement_size=max_cacheable_statement_size,
+        max_consecutive_exceptions=max_consecutive_exceptions,)
 
     return addrs, params, config
 

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1372,10 +1372,12 @@ class Connection(metaclass=ConnectionMeta):
         return result, stmt
 
     async def _maybe_close_bad_connection(self):
-        self._consecutive_exceptions += 1
-        if self._consecutive_exceptions > \
-                self._config.max_consecutive_exceptions:
-            await self.close()
+        if self._config.max_consecutive_exceptions > 0:
+            self._consecutive_exceptions += 1
+
+            if self._consecutive_exceptions > \
+                    self._config.max_consecutive_exceptions:
+                await self.close()
 
 
 async def connect(dsn=None, *,
@@ -1387,7 +1389,7 @@ async def connect(dsn=None, *,
                   statement_cache_size=100,
                   max_cached_statement_lifetime=300,
                   max_cacheable_statement_size=1024 * 15,
-                  max_consecutive_exceptions=5,
+                  max_consecutive_exceptions=0,
                   command_timeout=None,
                   ssl=None,
                   connection_class=Connection,
@@ -1447,7 +1449,7 @@ async def connect(dsn=None, *,
     :param int max_consecutive_exceptions:
         the maximum number of consecutive exceptions that may be raised by a
         single connection before that connection is assumed corrupt (ex.
-        pointing to an old DB after a failover)
+        pointing to an old DB after a failover). Pass ``0`` to disable.
 
     :param float command_timeout:
         the default timeout for operations on this connection

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1333,7 +1333,6 @@ class Connection(metaclass=ConnectionMeta):
             # the server's side), the only way is to drop our caches and
             # reraise the exception to the caller.
             #
-            await self._maybe_close_bad_connection()
             await self.reload_schema_state()
             raise
         except exceptions.InvalidCachedStatementError:
@@ -1359,7 +1358,6 @@ class Connection(metaclass=ConnectionMeta):
             # and https://github.com/MagicStack/asyncpg/issues/76
             # for discussion.
             #
-            await self._maybe_close_bad_connection()
             self._drop_global_statement_cache()
             if self._protocol.is_in_transaction() or not retry:
                 raise
@@ -1367,7 +1365,6 @@ class Connection(metaclass=ConnectionMeta):
                 return await self._do_execute(
                     query, executor, timeout, retry=False)
         except:
-            logging.warning('exception - maybe closing bad connection')
             await self._maybe_close_bad_connection()
             raise
 


### PR DESCRIPTION
This change might not be for everyone, so I respect the right of the core maintainers to downvote/close.

The backstory here is that I am using `asyncpg` to connect to an HA postgres cluster. In the event of a failover, the `writer` (where the `asyncpg` connection pool is connected to) crashes/fails, and is rebooted. The `reader` is then promoted to `writer`.  The DB DNS is automatically updated, but this takes time. In addition, the connections in the pool continue operating once the crashed DB recovers, except now that DB is the _reader_ (i.e. `SHOW transaction_read_only; -> on`). As a result, INSERT/UPDATE/DELETE operations result in:

```
asyncpg.exceptions.ReadOnlySQLTransactionError: cannot execute INSERT in a read-only transaction
```

Other errors, like timeouts, are also possible offenders. Unfortunately, the only way I've found around this to refresh the connections is to set a low `max_queries` config param. This is generally ok, but degrades performance due to increased cycles of closing and opening new connections.

With this PR, a configurable `max_consecutive_exceptions` config param is introduced. This param is checked against every time `_do_execute` results in an exception of any kind. _I would very much like to be more precise with exception handling_. Initially, I wanted to `except exceptions.__all__`, but some exception classes do not inherit from `Exception`, which causes other exceptions. I would certainly appreciate input on how to make the `_do_execute` catch-all more limited to asyncpg exceptions.