### PR TITLE
Fix server version parsing when it contains trailing data

### DIFF
--- a/asyncpg/serverversion.py
+++ b/asyncpg/serverversion.py
@@ -13,8 +13,12 @@ def split_server_version_string(version_string):
     if version_string.startswith('PostgreSQL '):
         version_string = version_string[len('PostgreSQL '):]
     if version_string.startswith('Postgres-XL'):
-        version_string = version_string[len('Postgre-XL '):]
+        version_string = version_string[len('Postgres-XL '):]
 
+    # Some distros (e.g Debian) like may inject their branding
+    # into the numeric version string, so make sure to only look
+    # at stuff before the first space.
+    version_string = version_string.split(' ')[0]
     parts = version_string.strip().split('.')
     if not parts[-1].isdigit():
         # release level specified

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -49,7 +49,7 @@ class TestSettings(tb.ConnectedTestCase):
     def test_server_version_02(self):
         versions = [
             ("9.2", (9, 2, 0, 'final', 0),),
-            ("9.2.1", (9, 2, 1, 'final', 0),),
+            ("Postgres-XL 9.2.1", (9, 2, 1, 'final', 0),),
             ("9.4beta1", (9, 4, 0, 'beta', 1),),
             ("10devel", (10, 0, 0, 'devel', 0),),
             ("10beta2", (10, 0, 0, 'beta', 2),),
@@ -57,6 +57,7 @@ class TestSettings(tb.ConnectedTestCase):
             # set version.minor to 0.
             ("10.1", (10, 0, 1, 'final', 0),),
             ("11.1.2", (11, 0, 1, 'final', 0),),
+            ("PostgreSQL 10.1 (Debian 10.1-3)", (10, 0, 1, 'final', 0),),
         ]
         for version, expected in versions:
             result = split_server_version_string(version)


### PR DESCRIPTION
Some distros (e.g Debian) like may inject their branding
into the numeric version string, so make sure to only look
at stuff before the first space.

Fixes: #250.