### PR TITLE
Add support for reading passwords from .pgpass

### DIFF
--- a/asyncpg/__init__.py
+++ b/asyncpg/__init__.py
@@ -15,4 +15,4 @@ from .types import *  # NOQA
 __all__ = ('connect', 'create_pool', 'Record', 'Connection') + \
           exceptions.__all__  # NOQA
 
-__version__ = '0.15.0'
+__version__ = '0.16.0.dev0'

--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -7,10 +7,13 @@
 
 import functools
 import os
+import pathlib
+import platform
 import sys
 
 
 PY_36 = sys.version_info >= (3, 6)
+SYSTEM = platform.uname().system
 
 
 if sys.version_info < (3, 5, 2):
@@ -45,3 +48,24 @@ else:
                     type(path).__name__
                 )
             )
+
+
+if SYSTEM == 'Windows':
+    import ctypes.wintypes
+
+    CSIDL_APPDATA = 0x001a
+
+    def get_pg_home_directory() -> pathlib.Path:
+        # We cannot simply use expanduser() as that returns the user's
+        # home directory, whereas Postgres stores its config in
+        # %AppData% on Windows.
+        buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
+        r = ctypes.windll.shell32.SHGetFolderPathW(0, CSIDL_APPDATA, 0, 0, buf)
+        if r:
+            return None
+        else:
+            return pathlib.Path(buf.value) / 'postgresql'
+
+else:
+    def get_pg_home_directory() -> pathlib.Path:
+        return pathlib.Path.home()

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1382,7 +1382,7 @@ class Connection(metaclass=ConnectionMeta):
 
 async def connect(dsn=None, *,
                   host=None, port=None,
-                  user=None, password=None,
+                  user=None, password=None, passfile=None,
                   database=None,
                   loop=None,
                   timeout=60,
@@ -1423,6 +1423,11 @@ async def connect(dsn=None, *,
 
     :param password:
         password used for authentication
+
+    :param passfile:
+        the name of the file used to store passwords
+        (defaults to ``~/.pgpass``, or ``%APPDATA%\postgresql\pgpass.conf``
+         on Windows)
 
     :param loop:
         An asyncio event loop instance.  If ``None``, the default
@@ -1489,6 +1494,10 @@ async def connect(dsn=None, *,
     .. versionadded:: 0.11.0
        Added ``connection_class`` parameter.
 
+    .. versionadded:: 0.16.0
+       Added ``passfile`` parameter
+       (and support for password files in general).
+
     .. _SSLContext: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
     .. _create_default_context: https://docs.python.org/3/library/ssl.html#\
                                 ssl.create_default_context
@@ -1503,7 +1512,8 @@ async def connect(dsn=None, *,
 
     return await connect_utils._connect(
         loop=loop, timeout=timeout, connection_class=connection_class,
-        dsn=dsn, host=host, port=port, user=user, password=password,
+        dsn=dsn, host=host, port=port, user=user,
+        password=password, passfile=passfile,
         ssl=ssl, database=database,
         server_settings=server_settings,
         command_timeout=command_timeout,


### PR DESCRIPTION
This largely mirrors libpq's behaviour with respect to ~/.pgpass.

Fixes: #267.