### PR TITLE
Prohibit non-iterable containers to be passed as array input

### DIFF
--- a/asyncpg/__init__.py
+++ b/asyncpg/__init__.py
@@ -15,4 +15,4 @@ from .types import *  # NOQA
 __all__ = ('connect', 'create_pool', 'Record', 'Connection') + \
           exceptions.__all__  # NOQA
 
-__version__ = '0.15.0'
+__version__ = '0.16.0.dev0'


### PR DESCRIPTION
Make the array input type check for correct ABCs instead of producing a
cryptic error when a non-iterable container is passed.