### PR TITLE
Fix for zero numeric

### DIFF
--- a/asyncpg/protocol/codecs/numeric.pyx
+++ b/asyncpg/protocol/codecs/numeric.pyx
@@ -161,7 +161,7 @@ cdef numeric_decode_binary(ConnectionSettings settings, FastReadBuffer buf):
 
     if num_pgdigits == 0:
         # Zero
-        return _Dec()
+        return _Dec('0e-' + str(dscale))
 
     pgdigit0 = hton.unpack_int16(buf.read(2))
     if weight >= 0:


### PR DESCRIPTION
Example:
If column has type numeric(2), then `str(column)` returns "0.00" instead of "0" (before this fix)