### PR TITLE
[RFC] Combine args of `executemany()` in batches

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -260,6 +260,15 @@ class Connection(metaclass=ConnectionMeta):
 
         .. versionchanged:: 0.11.0
            `timeout` became a keyword-only parameter.
+
+        .. versionchanged:: 0.16.0
+           The execution was changed to be in a implicit transaction if there
+           was no explicit transaction, so that it will no longer end up with
+           partial success. It also combined all args into one network packet
+           to reduce round-trip time, therefore you should make sure not to
+           blow up your memory with a super long iterable. If you still need
+           the previous behavior to progressively execute many args, please use
+           prepared statement instead.
         """
         self._check_open()
         return await self._executemany(command, args, timeout)

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -75,11 +75,6 @@ cdef class CoreProtocol:
         bint _skip_discard
         bint _discard_data
 
-        # executemany support data
-        object _execute_iter
-        str _execute_portal_name
-        str _execute_stmt_name
-
         ConnectionStatus con_status
         ProtocolState state
         TransactionStatus xact_status


### PR DESCRIPTION
Is it a good idea to combine all the args in `executemany()` into a ~single network packet~ single buffer to send (thx Yury) with a list of `Bind` and `Execute` command pairs? And, is it a good idea to make this method atomic? Please kindly give me some advices when time. Many thanks!

* Ends with only one `Sync` command, that means `executemany()` will be atomic in an implicit transaction, if not called from an existing transaction.
* This should reduce round-trip time to database back and forth, with a cost that ...
* memory usage is no longer smooth - it will have to encode all the bind args into memory before sending to database in a batch.
  * Theoretically it is possible to combine the args into small groups, in order for a balance between reduced RTT and memory usage, as well as to detect an error earlier.
* Assuming that reducing RTT is helpful, this RFC also added `executemany()` to prepared statement.

References:
* https://www.postgresql.org/docs/10/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
* https://www.pgcon.org/2014/schedule/attachments/330_postgres-for-the-wire.pdf
* https://www.youtube.com/watch?v=qa22SouCr5E
* https://github.com/MagicStack/asyncpg/issues/36