### PR TITLE
Upgrade to Cython 0.28.2

### DIFF
--- a/.ci/requirements-win.txt
+++ b/.ci/requirements-win.txt
@@ -1,2 +1,2 @@
-cython>=0.27.2
+cython>=0.28.2
 tinys3

--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.27.2
+cython>=0.28.2
 flake8>=3.4.1
 uvloop>=0.8.0
 tinys3

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -147,6 +147,7 @@ cdef class BaseProtocol(CoreProtocol):
             self.is_reading = False
             self.transport.pause_reading()
 
+    @cython.iterable_coroutine
     async def prepare(self, stmt_name, query, timeout,
                       PreparedStatementState state=None):
         if self.cancel_waiter is not None:
@@ -171,6 +172,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def bind_execute(self, PreparedStatementState state, args,
                            str portal_name, int limit, return_extra,
                            timeout):
@@ -203,6 +205,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def bind_execute_many(self, PreparedStatementState state, args,
                                 str portal_name, timeout):
 
@@ -238,6 +241,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def bind(self, PreparedStatementState state, args,
                    str portal_name, timeout):
 
@@ -266,6 +270,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def execute(self, PreparedStatementState state,
                       str portal_name, int limit, return_extra,
                       timeout):
@@ -295,6 +300,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def query(self, query, timeout):
         if self.cancel_waiter is not None:
             await self.cancel_waiter
@@ -319,6 +325,7 @@ cdef class BaseProtocol(CoreProtocol):
         finally:
             return await waiter
 
+    @cython.iterable_coroutine
     async def copy_out(self, copy_stmt, sink, timeout):
         if self.cancel_waiter is not None:
             await self.cancel_waiter
@@ -373,6 +380,7 @@ cdef class BaseProtocol(CoreProtocol):
 
         return status_msg
 
+    @cython.iterable_coroutine
     async def copy_in(self, copy_stmt, reader, data,
                       records, PreparedStatementState record_stmt, timeout):
         cdef:
@@ -491,6 +499,7 @@ cdef class BaseProtocol(CoreProtocol):
 
         return status_msg
 
+    @cython.iterable_coroutine
     async def close_statement(self, PreparedStatementState state, timeout):
         if self.cancel_waiter is not None:
             await self.cancel_waiter
@@ -530,6 +539,7 @@ cdef class BaseProtocol(CoreProtocol):
         self._terminate()
         self.transport.abort()
 
+    @cython.iterable_coroutine
     async def close(self, timeout):
         if self.closing:
             return
@@ -651,6 +661,7 @@ cdef class BaseProtocol(CoreProtocol):
             self.cancel_sent_waiter is not None
         )
 
+    @cython.iterable_coroutine
     async def _wait_for_cancellation(self):
         if self.cancel_sent_waiter is not None:
             await self.cancel_sent_waiter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-Cython>=0.25.2
+Cython>=0.28.2
 flake8>=3.4.1
 pytest>=3.0.7
 uvloop>=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@
 import os
 import os.path
 import platform
-import re
 import sys
 
 import setuptools
@@ -101,77 +100,7 @@ class build_ext(_build_ext.build_ext):
                 compiler_directives=directives,
                 annotate=self.cython_annotate)
 
-            for cfile, timestamp in cfiles.items():
-                if os.path.getmtime(cfile) != timestamp:
-                    # The file was recompiled, patch
-                    self._patch_cfile(cfile)
-
         super(build_ext, self).finalize_options()
-
-    def _patch_cfile(self, cfile):
-        # Script to patch Cython 'async def' coroutines to have a 'tp_iter'
-        # slot, which makes them compatible with 'yield from' without the
-        # `asyncio.coroutine` decorator.
-
-        with open(cfile, 'rt') as f:
-            src = f.read()
-
-        src = re.sub(
-            r'''
-            \s* offsetof\(__pyx_CoroutineObject,\s*gi_weakreflist\),
-            \s* 0,
-            \s* 0,
-            \s* __pyx_Coroutine_methods,
-            \s* __pyx_Coroutine_memberlist,
-            \s* __pyx_Coroutine_getsets,
-            ''',
-
-            r'''
-            offsetof(__pyx_CoroutineObject, gi_weakreflist),
-            __Pyx_Coroutine_await, /* tp_iter */
-            (iternextfunc) __Pyx_Generator_Next, /* tp_iternext */
-            __pyx_Coroutine_methods,
-            __pyx_Coroutine_memberlist,
-            __pyx_Coroutine_getsets,
-            ''',
-
-            src, flags=re.X)
-
-        # Fix a segfault in Cython.
-        src = re.sub(
-            r'''
-            \s* __Pyx_Coroutine_get_qualname\(__pyx_CoroutineObject\s+\*self\)
-            \s* {
-            \s* Py_INCREF\(self->gi_qualname\);
-            ''',
-
-            r'''
-            __Pyx_Coroutine_get_qualname(__pyx_CoroutineObject *self)
-            {
-                if (self->gi_qualname == NULL) { return __pyx_empty_unicode; }
-                Py_INCREF(self->gi_qualname);
-            ''',
-
-            src, flags=re.X)
-
-        src = re.sub(
-            r'''
-            \s* __Pyx_Coroutine_get_name\(__pyx_CoroutineObject\s+\*self\)
-            \s* {
-            \s* Py_INCREF\(self->gi_name\);
-            ''',
-
-            r'''
-            __Pyx_Coroutine_get_name(__pyx_CoroutineObject *self)
-            {
-                if (self->gi_name == NULL) { return __pyx_empty_unicode; }
-                Py_INCREF(self->gi_name);
-            ''',
-
-            src, flags=re.X)
-
-        with open(cfile, 'wt') as f:
-            f.write(src)
 
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:


### PR DESCRIPTION
Start using the new @cython.iterable_coroutine decorator. This allows
us to stop patching the generated C code to get compatibility with
generator-based coroutines.