### PR TITLE
Make Pool.close() wait until all checked out connections are released

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -74,8 +74,7 @@ class PoolConnectionProxy(connection._ConnectionProxy,
 
     def _detach(self) -> connection.Connection:
         if self._con is None:
-            raise exceptions.InterfaceError(
-                'cannot detach PoolConnectionProxy: already detached')
+            return
 
         con, self._con = self._con, None
         con._set_proxy(None)
@@ -92,7 +91,7 @@ class PoolConnectionProxy(connection._ConnectionProxy,
 
 class PoolConnectionHolder:
 
-    __slots__ = ('_con', '_pool', '_loop',
+    __slots__ = ('_con', '_pool', '_loop', '_proxy',
                  '_connect_args', '_connect_kwargs',
                  '_max_queries', '_setup', '_init',
                  '_max_inactive_time', '_in_use',
@@ -103,6 +102,7 @@ class PoolConnectionHolder:
 
         self._pool = pool
         self._con = None
+        self._proxy = None
 
         self._connect_args = connect_args
         self._connect_kwargs = connect_kwargs
@@ -111,11 +111,14 @@ class PoolConnectionHolder:
         self._setup = setup
         self._init = init
         self._inactive_callback = None
-        self._in_use = False
+        self._in_use = None  # type: asyncio.Future
         self._timeout = None
 
     async def connect(self):
-        assert self._con is None
+        if self._con is not None:
+            raise exceptions.InternalClientError(
+                'PoolConnectionHolder.connect() called while another '
+                'connection already exists')
 
         if self._pool._working_addr is None:
             # First connection attempt on this pool.
@@ -152,7 +155,7 @@ class PoolConnectionHolder:
 
         self._maybe_cancel_inactive_callback()
 
-        proxy = PoolConnectionProxy(self, self._con)
+        self._proxy = proxy = PoolConnectionProxy(self, self._con)
 
         if self._setup is not None:
             try:
@@ -163,101 +166,138 @@ class PoolConnectionHolder:
                 # we close it.  A new connection will be created
                 # when `acquire` is called again.
                 try:
-                    proxy._detach()
-                    # Use `close` to close the connection gracefully.
+                    # Use `close()` to close the connection gracefully.
                     # An exception in `setup` isn't necessarily caused
-                    # by an IO or a protocol error.
+                    # by an IO or a protocol error.  close() will
+                    # do the necessary cleanup via _release_on_close().
                     await self._con.close()
                 finally:
-                    self._con = None
                     raise ex
 
-        self._in_use = True
+        self._in_use = self._pool._loop.create_future()
+
         return proxy
 
     async def release(self, timeout):
-        assert self._in_use
-        self._in_use = False
+        if self._in_use is None:
+            raise exceptions.InternalClientError(
+                'PoolConnectionHolder.release() called on '
+                'a free connection holder')
+
+        if self._con.is_closed():
+            # When closing, pool connections perform the necessary
+            # cleanup, so we don't have to do anything else here.
+            return
+
         self._timeout = None
 
-        if self._con.is_closed():
-            self._con = None
+        if self._con._protocol.queries_count >= self._max_queries:
+            # The connection has reached its maximum utilization limit,
+            # so close it.  Connection.close() will call _release().
+            await self._con.close(timeout=timeout)
+            return
 
-        elif self._con._protocol.queries_count >= self._max_queries:
+        try:
+            budget = timeout
+
+            if self._con._protocol._is_cancelling():
+                # If the connection is in cancellation state,
+                # wait for the cancellation
+                started = time.monotonic()
+                await asyncio.wait_for(
+                    self._con._protocol._wait_for_cancellation(),
+                    budget, loop=self._pool._loop)
+                if budget is not None:
+                    budget -= time.monotonic() - started
+
+            await self._con.reset(timeout=budget)
+        except Exception as ex:
+            # If the `reset` call failed, terminate the connection.
+            # A new one will be created when `acquire` is called
+            # again.
             try:
-                await self._con.close(timeout=timeout)
+                # An exception in `reset` is most likely caused by
+                # an IO error, so terminate the connection.
+                self._con.terminate()
             finally:
-                self._con = None
+                raise ex
 
+        # Free this connection holder and invalidate the
+        # connection proxy.
+        self._release()
+
+        # Rearm the connection inactivity timer.
+        self._setup_inactive_callback()
+
+    async def wait_until_released(self):
+        if self._in_use is None:
+            return
         else:
-            try:
-                budget = timeout
-
-                if self._con._protocol._is_cancelling():
-                    # If the connection is in cancellation state,
-                    # wait for the cancellation
-                    started = time.monotonic()
-                    await asyncio.wait_for(
-                        self._con._protocol._wait_for_cancellation(),
-                        budget, loop=self._pool._loop)
-                    if budget is not None:
-                        budget -= time.monotonic() - started
-
-                await self._con.reset(timeout=budget)
-            except Exception as ex:
-                # If the `reset` call failed, terminate the connection.
-                # A new one will be created when `acquire` is called
-                # again.
-                try:
-                    # An exception in `reset` is most likely caused by
-                    # an IO error, so terminate the connection.
-                    self._con.terminate()
-                finally:
-                    self._con = None
-                    raise ex
-
-        assert self._inactive_callback is None
-        if self._max_inactive_time and self._con is not None:
-            self._inactive_callback = self._pool._loop.call_later(
-                self._max_inactive_time, self._deactivate_connection)
+            await self._in_use
 
     async def close(self):
-        self._maybe_cancel_inactive_callback()
-        if self._con is None:
-            return
-        if self._con.is_closed():
-            self._con = None
-            return
-
-        try:
+        if self._con is not None:
+            # Connection.close() will call _release_on_close() to
+            # finish holder cleanup.
             await self._con.close()
-        finally:
-            self._con = None
 
     def terminate(self):
-        self._maybe_cancel_inactive_callback()
-        if self._con is None:
-            return
-        if self._con.is_closed():
-            self._con = None
-            return
-
-        try:
+        if self._con is not None:
+            # Connection.terminate() will call _release_on_close() to
+            # finish holder cleanup.
             self._con.terminate()
-        finally:
-            self._con = None
+
+    def _setup_inactive_callback(self):
+        if self._inactive_callback is not None:
+            raise exceptions.InternalClientError(
+                'pool connection inactivity timer already exists')
+
+        if self._max_inactive_time:
+            self._inactive_callback = self._pool._loop.call_later(
+                self._max_inactive_time, self._deactivate_inactive_connection)
 
     def _maybe_cancel_inactive_callback(self):
         if self._inactive_callback is not None:
             self._inactive_callback.cancel()
             self._inactive_callback = None
 
-    def _deactivate_connection(self):
-        assert not self._in_use
-        if self._con is None or self._con.is_closed():
-            return
-        self._con.terminate()
+    def _deactivate_inactive_connection(self):
+        if self._in_use is not None:
+            raise exceptions.InternalClientError(
+                'attempting to deactivate an acquired connection')
+
+        if self._con is not None:
+            # The connection is idle and not in use, so it's fine to
+            # use terminate() instead of close().
+            self._con.terminate()
+            # Must call clear_connection, because _deactivate_connection
+            # is called when the connection is *not* checked out, and
+            # so terminate() above will not call the below.
+            self._release_on_close()
+
+    def _release_on_close(self):
+        self._maybe_cancel_inactive_callback()
+        self._release()
         self._con = None
+
+    def _release(self):
+        """Release this connection holder."""
+        if self._in_use is None:
+            # The holder is not checked out.
+            return
+
+        if not self._in_use.done():
+            self._in_use.set_result(None)
+        self._in_use = None
+
+        # Deinitialize the connection proxy.  All subsequent
+        # operations on it will fail.
+        if self._proxy is not None:
+            self._proxy._detach()
+            self._proxy = None
+
+        # Put ourselves back to the pool queue.
+        self._pool._queue.put_nowait(self)
 
 
 class Pool:
@@ -273,7 +313,7 @@ class Pool:
 
     __slots__ = ('_queue', '_loop', '_minsize', '_maxsize',
                  '_working_addr', '_working_config', '_working_params',
-                 '_holders', '_initialized', '_closed',
+                 '_holders', '_initialized', '_closing', '_closed',
                  '_connection_class')
 
     def __init__(self, *connect_args,
@@ -322,6 +362,7 @@ class Pool:
 
         self._connection_class = connection_class
 
+        self._closing = False
         self._closed = False
 
         for _ in range(max_size):
@@ -468,7 +509,10 @@ class Pool:
                 ch._timeout = timeout
                 return proxy
 
+        if self._closing:
+            raise exceptions.InterfaceError('pool is closing')
         self._check_init()
+
         if timeout is None:
             return await _acquire_impl()
         else:
@@ -488,14 +532,6 @@ class Pool:
         .. versionchanged:: 0.14.0
             Added the *timeout* parameter.
         """
-        async def _release_impl(ch: PoolConnectionHolder, timeout: float):
-            try:
-                await ch.release(timeout)
-            finally:
-                self._queue.put_nowait(ch)
-
-        self._check_init()
-
         if (type(connection) is not PoolConnectionProxy or
                 connection._holder._pool is not self):
             raise exceptions.InterfaceError(
@@ -507,35 +543,64 @@ class Pool:
             # Already released, do nothing.
             return
 
-        con = connection._detach()
-        con._on_release()
+        self._check_init()
 
+        # Let the connection do its internal housekeeping when its released.
+        connection._con._on_release()
+
+        ch = connection._holder
         if timeout is None:
-            timeout = connection._holder._timeout
+            timeout = ch._timeout
 
         # Use asyncio.shield() to guarantee that task cancellation
         # does not prevent the connection from being returned to the
         # pool properly.
-        return await asyncio.shield(
-            _release_impl(connection._holder, timeout), loop=self._loop)
+        return await asyncio.shield(ch.release(timeout), loop=self._loop)
 
     async def close(self):
-        """Gracefully close all connections in the pool."""
+        """Attempt to gracefully close all connections in the pool.
+
+        Wait until all pool connections are released, close them and
+        shut down the pool.  If any error (including cancellation) occurs
+        in ``close()`` the pool will terminate by calling
+        :meth:'Pool.terminate() <pool.Pool.terminate>`.
+
+        .. versionchanged:: 0.16.0
+            ``close()`` now waits until all pool connections are released
+            before closing them and the pool.  Errors raised in ``close()``
+            will cause immediate pool termination.
+        """
         if self._closed:
             return
         self._check_init()
-        self._closed = True
-        coros = [ch.close() for ch in self._holders]
-        await asyncio.gather(*coros, loop=self._loop)
+
+        self._closing = True
+
+        try:
+            release_coros = [
+                ch.wait_until_released() for ch in self._holders]
+            await asyncio.gather(*release_coros, loop=self._loop)
+
+            close_coros = [
+                ch.close() for ch in self._holders]
+            await asyncio.gather(*close_coros, loop=self._loop)
+
+        except Exception:
+            self.terminate()
+            raise
+
+        finally:
+            self._closed = True
+            self._closing = False
 
     def terminate(self):
         """Terminate all connections in the pool."""
         if self._closed:
             return
         self._check_init()
-        self._closed = True
         for ch in self._holders:
             ch.terminate()
+        self._closed = True
 
     def _check_init(self):
         if not self._initialized:

--- a/tests/test_cache_invalidation.py
+++ b/tests/test_cache_invalidation.py
@@ -85,6 +85,8 @@ class TestCacheInvalidation(tb.ConnectedTestCase):
 
         finally:
             await self.con.execute('DROP TABLE tab1')
+            await pool.release(con2)
+            await pool.release(con1)
             await pool.close()
 
     async def test_type_cache_invalidation_in_transaction(self):
@@ -303,6 +305,9 @@ class TestCacheInvalidation(tb.ConnectedTestCase):
         finally:
             await self.con.execute('DROP TABLE tab1')
             await self.con.execute('DROP TYPE typ1')
+            await pool.release(con2)
+            await pool.release(con1)
             await pool.close()
+            await pool_chk.release(con_chk)
             await pool_chk.close()
             await self.con.execute('DROP DATABASE testdb')


### PR DESCRIPTION
Currently, `pool.close()`, despite the "graceful" designation, closes
all connections immediately regardless of whether they are acquired.

With this change, pool will wait for connections to actually be released
before closing.

WARNING: This is a potentially incompatible behavior change, as sloppily
written code which does not release acquired connections will now cause
`pool.close()` to hang forever.

Also, when `conn.close()` or `conn.terminate()` are called directly
on an acquired connection, the associated pool item is released
immediately.

Closes: #290