### PR TITLE
Fix handling of OIDs >= 2**31

### DIFF
--- a/asyncpg/cluster.py
+++ b/asyncpg/cluster.py
@@ -106,7 +106,8 @@ class Cluster:
             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = process.stdout, process.stderr
 
-        if process.returncode == 4 or not os.listdir(self._data_dir):
+        if (process.returncode == 4 or not os.path.exists(self._data_dir) or
+                not os.listdir(self._data_dir)):
             return 'not-initialized'
         elif process.returncode == 3:
             return 'stopped'

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -913,12 +913,12 @@ class Connection(metaclass=ConnectionMeta):
         if not typeinfo:
             raise ValueError('unknown type: {}.{}'.format(schema, typename))
 
-        oid = typeinfo['oid']
-        if typeinfo['kind'] != b'b' or typeinfo['elemtype']:
+        if not introspection.is_scalar_type(typeinfo):
             raise ValueError(
                 'cannot use custom codec on non-scalar type {}.{}'.format(
                     schema, typename))
 
+        oid = typeinfo['oid']
         self._protocol.get_settings().add_python_codec(
             oid, typename, schema, 'scalar',
             encoder, decoder, format)

--- a/asyncpg/introspection.py
+++ b/asyncpg/introspection.py
@@ -145,3 +145,14 @@ FROM
 WHERE
     t.typname = $1 AND ns.nspname = $2
 '''
+
+
+# 'b' for a base type, 'd' for a domain, 'e' for enum.
+SCALAR_TYPE_KINDS = (b'b', b'd', b'e')
+
+
+def is_scalar_type(typeinfo) -> bool:
+    return (
+        typeinfo['kind'] in SCALAR_TYPE_KINDS and
+        not typeinfo['elemtype']
+    )

--- a/asyncpg/protocol/buffer.pxd
+++ b/asyncpg/protocol/buffer.pxd
@@ -97,13 +97,13 @@ cdef class ReadBuffer:
     cdef feed_data(self, data)
     cdef inline _ensure_first_buf(self)
     cdef _switch_to_next_buf(self)
-    cdef inline read_byte(self)
+    cdef inline char read_byte(self) except? -1
     cdef inline const char* _try_read_bytes(self, ssize_t nbytes)
     cdef inline _read(self, char *buf, ssize_t nbytes)
     cdef read(self, ssize_t nbytes)
     cdef inline const char* read_bytes(self, ssize_t n) except NULL
-    cdef inline read_int32(self)
-    cdef inline read_int16(self)
+    cdef inline int32_t read_int32(self) except? -1
+    cdef inline int16_t read_int16(self) except? -1
     cdef inline read_cstr(self)
     cdef int32_t has_message(self) except -1
     cdef inline int32_t has_message_type(self, char mtype) except -1

--- a/asyncpg/protocol/buffer.pyx
+++ b/asyncpg/protocol/buffer.pyx
@@ -376,7 +376,7 @@ cdef class ReadBuffer:
 
         return Memory.new(buf, result, nbytes)
 
-    cdef inline read_byte(self):
+    cdef inline char read_byte(self) except? -1:
         cdef const char *first_byte
 
         if ASYNCPG_DEBUG:
@@ -404,7 +404,7 @@ cdef class ReadBuffer:
             mem = <Memory>(self.read(n))
             return mem.buf
 
-    cdef inline read_int32(self):
+    cdef inline int32_t read_int32(self) except? -1:
         cdef:
             Memory mem
             const char *cbuf
@@ -417,7 +417,7 @@ cdef class ReadBuffer:
             mem = <Memory>(self.read(4))
             return hton.unpack_int32(mem.buf)
 
-    cdef inline read_int16(self):
+    cdef inline int16_t read_int16(self) except? -1:
         cdef:
             Memory mem
             const char *cbuf

--- a/asyncpg/protocol/codecs/misc.pyx
+++ b/asyncpg/protocol/codecs/misc.pyx
@@ -36,8 +36,8 @@ cdef init_pseudo_codecs():
 
     for oid_type in oid_types:
         register_core_codec(oid_type,
-                            <encode_func>&int4_encode,
-                            <decode_func>&int4_decode,
+                            <encode_func>&uint4_encode,
+                            <decode_func>&uint4_decode,
                             PG_FORMAT_BINARY)
 
     # reg* types -- these are really system catalog OIDs, but

--- a/asyncpg/protocol/codecs/tid.pyx
+++ b/asyncpg/protocol/codecs/tid.pyx
@@ -23,9 +23,9 @@ cdef tid_encode(ConnectionSettings settings, WriteBuffer buf, obj):
         overflow = 1
 
     # "long" and "long long" have the same size for x86_64, need an extra check
-    if overflow or (sizeof(block) > 4 and block > 4294967295):
+    if overflow or (sizeof(block) > 4 and block > UINT32_MAX):
         raise OverflowError(
-            'block too big to be encoded as UINT4: {!r}'.format(obj[0]))
+            'tuple id block value out of range: {!r}'.format(obj[0]))
 
     try:
         offset = cpython.PyLong_AsUnsignedLong(obj[1])
@@ -35,7 +35,7 @@ cdef tid_encode(ConnectionSettings settings, WriteBuffer buf, obj):
 
     if overflow or offset > 65535:
         raise OverflowError(
-            'offset too big to be encoded as UINT2: {!r}'.format(obj[1]))
+            'tuple id offset value out of range: {!r}'.format(obj[1]))
 
     buf.write_int32(6)
     buf.write_int32(<int32_t>block)

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -163,7 +163,7 @@ cdef class PreparedStatementState:
             list cols_names
             object cols_mapping
             tuple row
-            int oid
+            uint32_t oid
             Codec codec
             list codecs
 
@@ -183,7 +183,7 @@ cdef class PreparedStatementState:
             cols_mapping[col_name] = i
             cols_names.append(col_name)
             oid = row[3]
-            codec = self.settings.get_data_codec(<uint32_t>oid)
+            codec = self.settings.get_data_codec(oid)
             if codec is None or not codec.has_decoder():
                 raise RuntimeError('no decoder for OID {}'.format(oid))
             if not codec.is_binary():
@@ -198,7 +198,7 @@ cdef class PreparedStatementState:
 
     cdef _ensure_args_encoder(self):
         cdef:
-            int p_oid
+            uint32_t p_oid
             Codec codec
             list codecs = []
 
@@ -207,7 +207,7 @@ cdef class PreparedStatementState:
 
         for i from 0 <= i < self.args_num:
             p_oid = self.parameters_desc[i]
-            codec = self.settings.get_data_codec(<uint32_t>p_oid)
+            codec = self.settings.get_data_codec(p_oid)
             if codec is None or not codec.has_encoder():
                 raise RuntimeError('no encoder for OID {}'.format(p_oid))
             if codec.type not in {}:
@@ -290,14 +290,14 @@ cdef _decode_parameters_desc(object desc):
     cdef:
         ReadBuffer reader
         int16_t nparams
-        int32_t p_oid
+        uint32_t p_oid
         list result = []
 
     reader = ReadBuffer.new_message_parser(desc)
     nparams = reader.read_int16()
 
     for i from 0 <= i < nparams:
-        p_oid = reader.read_int32()
+        p_oid = <uint32_t>reader.read_int32()
         result.append(p_oid)
 
     return result
@@ -310,9 +310,9 @@ cdef _decode_row_desc(object desc):
         int16_t nfields
 
         bytes f_name
-        int32_t f_table_oid
+        uint32_t f_table_oid
         int16_t f_column_num
-        int32_t f_dt_oid
+        uint32_t f_dt_oid
         int16_t f_dt_size
         int32_t f_dt_mod
         int16_t f_format
@@ -325,9 +325,9 @@ cdef _decode_row_desc(object desc):
 
     for i from 0 <= i < nfields:
         f_name = reader.read_cstr()
-        f_table_oid = reader.read_int32()
+        f_table_oid = <uint32_t>reader.read_int32()
         f_column_num = reader.read_int16()
-        f_dt_oid = reader.read_int32()
+        f_dt_oid = <uint32_t>reader.read_int32()
         f_dt_size = reader.read_int16()
         f_dt_mod = reader.read_int32()
         f_format = reader.read_int16()

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -18,7 +18,9 @@ import socket
 import time
 
 from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
-                         int32_t, uint32_t, int64_t, uint64_t
+                         int32_t, uint32_t, int64_t, uint64_t, \
+                         INT16_MIN, INT16_MAX, INT32_MIN, INT32_MAX, \
+                         UINT32_MAX, INT64_MIN, INT64_MAX
 
 from asyncpg.protocol cimport record
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -756,8 +756,9 @@ class TestSSLConnection(tb.ConnectedTestCase):
 
     @classmethod
     def setup_cluster(cls):
-        cls.cluster = cls.start_cluster(
-            pg_cluster.TempCluster, server_settings=cls.get_server_settings())
+        cls.cluster = cls.new_cluster(pg_cluster.TempCluster)
+        cls.start_cluster(
+            cls.cluster, server_settings=cls.get_server_settings())
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Currently asyncpg (incorrectly) assumes OIDs to be signed 32-bit
integers, whereas in reality they are unsigned.  As a result, things
would crash once the OID sequence reaches 2**31.

Fix this by decoding OID values as unsigned longs.

Fixes: #279