### PR TITLE
Fix type codec cache races

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -614,6 +614,12 @@ class Pool:
             if ch._con is not None:
                 ch._con._drop_local_statement_cache()
 
+    def _drop_type_cache(self):
+        # Drop type codec cache for all connections in the pool.
+        for ch in self._holders:
+            if ch._con is not None:
+                ch._con._drop_local_type_cache()
+
     def __await__(self):
         return self._async__init__().__await__()
 

--- a/asyncpg/protocol/codecs/base.pxd
+++ b/asyncpg/protocol/codecs/base.pxd
@@ -167,8 +167,8 @@ cdef class Codec:
 
 cdef class DataCodecConfig:
     cdef:
-        dict _type_codecs_cache
-        dict _local_type_codecs
+        dict _derived_type_codecs
+        dict _custom_type_codecs
 
     cdef inline Codec get_codec(self, uint32_t oid, ServerDataFormat format)
     cdef inline Codec get_local_codec(self, uint32_t oid)

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -63,24 +63,21 @@ cdef class PreparedStatementState:
     def _init_types(self):
         cdef:
             Codec codec
-            set result = set()
+            set missing = set()
 
         if self.parameters_desc:
             for p_oid in self.parameters_desc:
                 codec = self.settings.get_data_codec(<uint32_t>p_oid)
                 if codec is None or not codec.has_encoder():
-                    result.add(p_oid)
+                    missing.add(p_oid)
 
         if self.row_desc:
             for rdesc in self.row_desc:
                 codec = self.settings.get_data_codec(<uint32_t>(rdesc[3]))
                 if codec is None or not codec.has_decoder():
-                    result.add(rdesc[3])
+                    missing.add(rdesc[3])
 
-        if len(result):
-            return result
-        else:
-            return True
+        return missing
 
     cpdef _init_codecs(self):
         self._ensure_args_encoder()

--- a/asyncpg/protocol/settings.pxd
+++ b/asyncpg/protocol/settings.pxd
@@ -25,4 +25,5 @@ cdef class ConnectionSettings:
     cpdef inline clear_type_cache(self)
     cpdef inline set_builtin_type_codec(
         self, typeoid, typename, typeschema, typekind, alias_to)
-    cpdef inline Codec get_data_codec(self, uint32_t oid, ServerDataFormat format=*)
+    cpdef inline Codec get_data_codec(
+        self, uint32_t oid, ServerDataFormat format=*)


### PR DESCRIPTION
Current global type codec cache works poorly in a pooled environment.
The global nature of the cache makes introspection/cache bust race a
frequent occurrence.  Additionally, busting the codec cache in _all_
connections only because one of them had reconfigured a codec seems
wrong.

The fix is simple: every connection now has its own codec cache.  The
downside is that there will be more introspection queries on fresh
connections, but given that most connections in the field are pooled,
the robustness gains are more important.

Fixes: #278