### PR TITLE
Raise a consistent exception on input encoding errors

### DIFF
--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -209,6 +209,10 @@ class InterfaceError(InterfaceMessage, Exception):
         Exception.__init__(self, msg)
 
 
+class DataError(InterfaceError, ValueError):
+    """An error caused by invalid query input."""
+
+
 class InterfaceWarning(InterfaceMessage, UserWarning):
     """A warning caused by an improper use of asyncpg API."""
 

--- a/asyncpg/protocol/codecs/float.pyx
+++ b/asyncpg/protocol/codecs/float.pyx
@@ -12,7 +12,7 @@ cdef float4_encode(ConnectionSettings settings, WriteBuffer buf, obj):
     cdef double dval = cpython.PyFloat_AsDouble(obj)
     cdef float fval = <float>dval
     if math.isinf(fval) and not math.isinf(dval):
-        raise ValueError('float value too large to be encoded as FLOAT4')
+        raise ValueError('value out of float32 range')
 
     buf.write_int32(4)
     buf.write_float(fval)

--- a/asyncpg/protocol/codecs/int.pyx
+++ b/asyncpg/protocol/codecs/int.pyx
@@ -28,8 +28,7 @@ cdef int2_encode(ConnectionSettings settings, WriteBuffer buf, obj):
         overflow = 1
 
     if overflow or val < INT16_MIN or val > INT16_MAX:
-        raise OverflowError(
-            'int16 value out of range: {!r}'.format(obj))
+        raise OverflowError('value out of int16 range')
 
     buf.write_int32(2)
     buf.write_int16(<int16_t>val)
@@ -50,8 +49,7 @@ cdef int4_encode(ConnectionSettings settings, WriteBuffer buf, obj):
 
     # "long" and "long long" have the same size for x86_64, need an extra check
     if overflow or (sizeof(val) > 4 and (val < INT32_MIN or val > INT32_MAX)):
-        raise OverflowError(
-            'int32 value out of range: {!r}'.format(obj))
+        raise OverflowError('value out of int32 range')
 
     buf.write_int32(4)
     buf.write_int32(<int32_t>val)
@@ -72,8 +70,7 @@ cdef uint4_encode(ConnectionSettings settings, WriteBuffer buf, obj):
 
     # "long" and "long long" have the same size for x86_64, need an extra check
     if overflow or (sizeof(val) > 4 and val > UINT32_MAX):
-        raise OverflowError(
-            'uint32 value out of range: {!r}'.format(obj))
+        raise OverflowError('value out of uint32 range')
 
     buf.write_int32(4)
     buf.write_int32(<int32_t>val)
@@ -95,8 +92,7 @@ cdef int8_encode(ConnectionSettings settings, WriteBuffer buf, obj):
 
     # Just in case for systems with "long long" bigger than 8 bytes
     if overflow or (sizeof(val) > 8 and (val < INT64_MIN or val > INT64_MAX)):
-        raise OverflowError(
-            'int64 value out of range: {!r}'.format(obj))
+        raise OverflowError('value out of int64 range')
 
     buf.write_int32(8)
     buf.write_int64(<int64_t>val)

--- a/asyncpg/protocol/codecs/tid.pyx
+++ b/asyncpg/protocol/codecs/tid.pyx
@@ -24,8 +24,7 @@ cdef tid_encode(ConnectionSettings settings, WriteBuffer buf, obj):
 
     # "long" and "long long" have the same size for x86_64, need an extra check
     if overflow or (sizeof(block) > 4 and block > UINT32_MAX):
-        raise OverflowError(
-            'tuple id block value out of range: {!r}'.format(obj[0]))
+        raise OverflowError('tuple id block value out of uint32 range')
 
     try:
         offset = cpython.PyLong_AsUnsignedLong(obj[1])
@@ -34,8 +33,7 @@ cdef tid_encode(ConnectionSettings settings, WriteBuffer buf, obj):
         overflow = 1
 
     if overflow or offset > 65535:
-        raise OverflowError(
-            'tuple id offset value out of range: {!r}'.format(obj[1]))
+        raise OverflowError('tuple id offset value out of uint16 range')
 
     buf.write_int32(6)
     buf.write_int32(<int32_t>block)


### PR DESCRIPTION
Currently, when invalid input is passed a query argument, asyncpg will
raise whatever exception was triggered by the codec function, which
can be `TypeError`, `ValueError`, `decimal.InvalidOperation` etc.
Additionally, these exceptions lack sufficient context as to which
argument actually triggered an error.

Fix this by consistently raising the new `asyncpg.DataError` exception,
which is a subclass of `asyncpg.InterfaceError` and `ValueError`, and
include the position of the offending argument as well as the passed
value, e.g:

    asyncpg.exceptions.DataError: invalid input for query argument $1: 'aaa'
    (a bytes-like object is required, not 'str')

Fixes: #260