### PR TITLE
Modernize and improve setup.py

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -26,10 +26,9 @@ branches:
 
 install:
     - "%PYTHON% -m pip install --upgrade pip wheel setuptools"
-    - "%PYTHON% -m pip install --upgrade -r .ci/requirements-win.txt"
 
 build_script:
-    - "%PYTHON% setup.py build_ext --inplace"
+    - "%PYTHON% setup.py build_ext --inplace --cython-always"
 
 test_script:
     - "%PYTHON% setup.py test"
@@ -41,6 +40,7 @@ artifacts:
     - path: dist\*
 
 deploy_script:
+    - "%PYTHON% -m pip install --upgrade -r .ci/requirements-publish.txt"
     - ps: |
         if ($env:appveyor_repo_branch -eq 'releases') {
             $PACKAGE_VERSION = & "$env:PYTHON" ".ci/package-version.py"

--- a/.ci/requirements-publish.txt
+++ b/.ci/requirements-publish.txt
@@ -1,0 +1,2 @@
+tinys3
+twine

--- a/.ci/requirements-win.txt
+++ b/.ci/requirements-win.txt
@@ -1,2 +1,0 @@
-cython>=0.28.3
-tinys3

--- a/.ci/requirements.txt
+++ b/.ci/requirements.txt
@@ -1,5 +1,0 @@
-cython>=0.28.3
-flake8>=3.4.1
-uvloop>=0.8.0
-tinys3
-twine

--- a/.ci/travis-build-docs.sh
+++ b/.ci/travis-build-docs.sh
@@ -7,5 +7,5 @@ if [[ "${BUILD}" != *docs* ]]; then
     exit 0
 fi
 
-pip install -r docs/requirements.txt
+pip install -U .[dev]
 make htmldocs SPHINXOPTS="-q -W -j4"

--- a/.ci/travis-install.sh
+++ b/.ci/travis-install.sh
@@ -8,6 +8,5 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     eval "$(pyenv init -)"
 fi
 
-pip install --upgrade pip wheel
-pip install --upgrade setuptools
-pip install --upgrade -r .ci/requirements.txt
+pip install --upgrade setuptools pip wheel
+pip install --upgrade -e .[dev]

--- a/.ci/travis-publish-docs.sh
+++ b/.ci/travis-publish-docs.sh
@@ -13,7 +13,7 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
     exit 0
 fi
 
-pip install -r docs/requirements.txt
+pip install -U .[dev]
 make htmldocs
 
 git config --global user.email "infra@magic.io"

--- a/.ci/travis-release.sh
+++ b/.ci/travis-release.sh
@@ -7,6 +7,7 @@ if [ -z "${TRAVIS_TAG}" ]; then
     exit 0
 fi
 
+pip install -U ".ci/requirements-publish.txt"
 
 PACKAGE_VERSION=$(python ".ci/package-version.py")
 PYPI_VERSION=$(python ".ci/pypi-check.py" "${PYMODULE}")

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ docs/_build
 *,cover
 .coverage
 /.pytest_cache/
+/.eggs

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,7 @@ compile:
 
 
 debug:
-	$(PYTHON) setup.py build_ext --inplace --debug \
-		--cython-always \
-		--cython-annotate \
-		--cython-directives="linetrace=True" \
-		--define ASYNCPG_DEBUG,CYTHON_TRACE,CYTHON_TRACE_NOGIL
+	ASYNCPG_DEBUG=1 $(PYTHON) setup.py build_ext --inplace
 
 
 test:

--- a/asyncpg/__init__.py
+++ b/asyncpg/__init__.py
@@ -15,4 +15,20 @@ from .types import *  # NOQA
 __all__ = ('connect', 'create_pool', 'Record', 'Connection') + \
           exceptions.__all__  # NOQA
 
-__version__ = '0.16.0.dev1'
+# The rules of changing __version__:
+#
+#    In a release revision, __version__ must be set to 'x.y.z',
+#    and the release revision tagged with the 'vx.y.z' tag.
+#    For example, asyncpg release 0.15.0 should have
+#    __version__ set to '0.15.0', and tagged with 'v0.15.0'.
+#
+#    In between releases, __version__ must be set to
+#    'x.y+1.0.dev0', so asyncpg revisions between 0.15.0 and
+#    0.16.0 should have __version__ set to '0.16.0.dev0' in
+#    the source.
+#
+#    Source and wheel distributions built from development
+#    snapshots will automatically include the git revision
+#    in __version__, for example: '0.16.0.dev22+ge06ad03'
+
+__version__ = '0.16.0.dev0'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,29 +29,27 @@ If you want to build **asyncpg** from a Git checkout you will need:
   * CPython header files.  These can usually be obtained by installing
     the relevant Python development package: **python3-dev** on Debian/Ubuntu,
     **python3-devel** on RHEL/Fedora.
-  * Cython version 0.24 or later.  The easiest way to install it to use
-    virtualenv and pip, however a system package should also suffice.
-  * GNU make
 
-Once the above requirements are satisfied, run:
+Once the above requirements are satisfied, run the following command
+in the root of the source checkout:
 
 .. code-block:: bash
 
-    $ make
+    $ pip install -e .
 
-At this point you can run the usual ``setup.py`` commands or
-``pip install -e .`` to install the newly built version.
+A debug build containing more runtime checks can be created by setting
+the ``ASYNCPG_DEBUG`` environment variable when building:
 
-.. note::
+.. code-block:: bash
 
-   A debug build can be created by running ``make debug``.
+    $ env ASYNCPG_DEBUG=1 pip install -e .
 
 
 Running tests
 -------------
 
-To execute the testsuite simply run:
+To execute the testsuite run:
 
 .. code-block:: bash
 
-    $ make test
+    $ python setup.py test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-Cython>=0.28.3
-flake8>=3.4.1
-pytest>=3.0.7
-uvloop>=0.8.0


### PR DESCRIPTION
The current setup/CI configuration has rotted a bit, especially with
respect to the control of requirements.  This is a modernization pass to
fix that and make some improvements:

1) Various requirements are now specified directly in setup.py through
   "extras_require", so to install the dev dependencies it's sufficient
   to run `$ pip install -e .[dev]`

2) When building or installing unreleased versions of asyncpg, the dev
   version is generated automatically with setuptools_scm.

3) When cythonization is necessary, the correct version of Cython is now
   used automatically through the use of setup_requires.