### PR TITLE
Quoting channel name in LISTEN and UNLISTEN.

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -112,7 +112,7 @@ class Connection(metaclass=ConnectionMeta):
         """
         self._check_open()
         if channel not in self._listeners:
-            await self.fetch('LISTEN {}'.format(channel))
+            await self.fetch('LISTEN "{}"'.format(channel))
             self._listeners[channel] = set()
         self._listeners[channel].add(callback)
 
@@ -127,7 +127,7 @@ class Connection(metaclass=ConnectionMeta):
         self._listeners[channel].remove(callback)
         if not self._listeners[channel]:
             del self._listeners[channel]
-            await self.fetch('UNLISTEN {}'.format(channel))
+            await self.fetch('UNLISTEN "{}"'.format(channel))
 
     def add_log_listener(self, callback):
         """Add a listener for Postgres log messages.

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -112,7 +112,7 @@ class Connection(metaclass=ConnectionMeta):
         """
         self._check_open()
         if channel not in self._listeners:
-            await self.fetch('LISTEN "{}"'.format(channel))
+            await self.fetch('LISTEN {}'.format(utils._quote_ident(channel)))
             self._listeners[channel] = set()
         self._listeners[channel].add(callback)
 
@@ -127,7 +127,7 @@ class Connection(metaclass=ConnectionMeta):
         self._listeners[channel].remove(callback)
         if not self._listeners[channel]:
             del self._listeners[channel]
-            await self.fetch('UNLISTEN "{}"'.format(channel))
+            await self.fetch('UNLISTEN {}'.format(utils._quote_ident(channel)))
 
     def add_log_listener(self, callback):
         """Add a listener for Postgres log messages.

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -87,14 +87,14 @@ class TestListeners(tb.ClusterTestCase):
                 def listener1(*args):
                     q1.put_nowait(args)
 
-                await con1.add_listener('12+34', listener1)
-                await con2.execute("""NOTIFY "12+34", 'hello'""")
+                await con1.add_listener('12+"34', listener1)
+                await con2.execute("""NOTIFY "12+""34", 'hello'""")
 
                 self.assertEqual(
                     await q1.get(),
-                    (con1, con2.get_server_pid(), '12+34', 'hello'))
+                    (con1, con2.get_server_pid(), '12+"34', 'hello'))
 
-                await con1.remove_listener('12+34', listener1)
+                await con1.remove_listener('12+"34', listener1)
 
     async def test_dangling_listener_warns(self):
         async with self.create_pool(database='postgres') as pool:

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -78,6 +78,24 @@ class TestListeners(tb.ClusterTestCase):
 
                 await con1.remove_listener('ipc', listener1)
 
+    async def test_listen_notletters(self):
+        async with self.create_pool(database='postgres') as pool:
+            async with pool.acquire() as con1, pool.acquire() as con2:
+
+                q1 = asyncio.Queue(loop=self.loop)
+
+                def listener1(*args):
+                    q1.put_nowait(args)
+
+                await con1.add_listener('12+34', listener1)
+                await con2.execute("""NOTIFY "12+34", 'hello'""")
+
+                self.assertEqual(
+                    await q1.get(),
+                    (con1, con2.get_server_pid(), '12+34', 'hello'))
+
+                await con1.remove_listener('12+34', listener1)
+
     async def test_dangling_listener_warns(self):
         async with self.create_pool(database='postgres') as pool:
             with self.assertWarnsRegex(


### PR DESCRIPTION
Hello. I did not open an issue for this but I included a test. Roughly, channel names are not quoted when used with `listen` and `unlisten`. This causes PostgreSQL to yell at you, and an exception to be raised by asyncpg, if they have funny characters or are not valid identifiers. Also they're case insensitive:
> Quoting an identifier also makes it case-sensitive, whereas unquoted names are always folded to lower case. For example, the identifiers FOO, foo, and "foo" are considered the same by PostgreSQL...

As a result of quoting, this diff could break some asyncpg applications that listen on `FOO` with while another application notifies on `foo` or `FOO` or `"foo"`. Previously it would see all of those notifications, now it would see none of them. However, I think the current behaviour is unexpected.

(Also I imagine things could get weird here if a channel name contained a `"`)