### PR TITLE
Fix handling of large type OIDs

### DIFF
--- a/asyncpg/protocol/codecs/array.pyx
+++ b/asyncpg/protocol/codecs/array.pyx
@@ -804,23 +804,23 @@ cdef _infer_array_dims(const Py_UCS4 *array_text,
         ndims[0] = 0
 
 
-cdef int4_encode_ex(ConnectionSettings settings, WriteBuffer buf, object obj,
-                    const void *arg):
-    return int4_encode(settings, buf, obj)
+cdef uint4_encode_ex(ConnectionSettings settings, WriteBuffer buf, object obj,
+                     const void *arg):
+    return uint4_encode(settings, buf, obj)
 
 
-cdef int4_decode_ex(ConnectionSettings settings, FastReadBuffer buf,
-                    const void *arg):
-    return int4_decode(settings, buf)
+cdef uint4_decode_ex(ConnectionSettings settings, FastReadBuffer buf,
+                     const void *arg):
+    return uint4_decode(settings, buf)
 
 
 cdef arrayoid_encode(ConnectionSettings settings, WriteBuffer buf, items):
     array_encode(settings, buf, items, OIDOID,
-                 <encode_func_ex>&int4_encode_ex, NULL)
+                 <encode_func_ex>&uint4_encode_ex, NULL)
 
 
 cdef arrayoid_decode(ConnectionSettings settings, FastReadBuffer buf):
-    return array_decode(settings, buf, <decode_func_ex>&int4_decode_ex, NULL)
+    return array_decode(settings, buf, <decode_func_ex>&uint4_decode_ex, NULL)
 
 
 cdef text_encode_ex(ConnectionSettings settings, WriteBuffer buf, object obj,

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1610,6 +1610,11 @@ class TestCodecsLargeOIDs(tb.ConnectedTestCase):
             ''')
             self.assertEqual(oid, 2147483648)
 
+            # Test that introspection handles large OIDs
+            v = await self.con.fetchval('SELECT $1::test_domain_t', 10)
+            self.assertEqual(v, 10)
+
+            # Test that custom codec logic handles large OIDs
             await self.con.set_type_codec(
                 'test_domain_t',
                 encoder=lambda v: str(v),


### PR DESCRIPTION
This was partially fixed in #300 (as a fix for #279), however that fix
missed the fact that OID arrays were still handled using the signed
integer codec.

Fixes: #316