### PR TITLE
Break strong ref between Connection and Protocol.

### DIFF
--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -5,6 +5,7 @@
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
 
+import asyncio
 import functools
 import os
 import pathlib
@@ -13,6 +14,7 @@ import sys
 
 
 PY_36 = sys.version_info >= (3, 6)
+PY_37 = sys.version_info >= (3, 7)
 SYSTEM = platform.uname().system
 
 
@@ -69,3 +71,11 @@ if SYSTEM == 'Windows':
 else:
     def get_pg_home_directory() -> pathlib.Path:
         return pathlib.Path.home()
+
+
+if PY_37:
+    def current_asyncio_task(loop):
+        return asyncio.current_task(loop)
+else:
+    def current_asyncio_task(loop):
+        return asyncio.Task.current_task(loop)

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1159,7 +1159,7 @@ class Connection(metaclass=ConnectionMeta):
                 waiter.set_exception(ex)
         finally:
             self._cancellations.discard(
-                asyncio.Task.current_task(self._loop))
+                compat.current_asyncio_task(self._loop))
             if not waiter.done():
                 waiter.set_result(None)
             if w is not None:

--- a/asyncpg/protocol/prepared_stmt.pxd
+++ b/asyncpg/protocol/prepared_stmt.pxd
@@ -17,7 +17,6 @@ cdef class PreparedStatementState:
         list         row_desc
         list         parameters_desc
 
-        BaseProtocol protocol
         ConnectionSettings settings
 
         int16_t      args_num

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -14,7 +14,6 @@ cdef class PreparedStatementState:
     def __cinit__(self, str name, str query, BaseProtocol protocol):
         self.name = name
         self.query = query
-        self.protocol = protocol
         self.settings = protocol.settings
         self.row_desc = self.parameters_desc = None
         self.args_codecs = self.rows_codecs = None

--- a/asyncpg/protocol/protocol.pxd
+++ b/asyncpg/protocol/protocol.pxd
@@ -36,7 +36,7 @@ cdef class BaseProtocol(CoreProtocol):
         object timeout_handle
         object timeout_callback
         object completed_callback
-        object connection
+        object conref
         bint is_reading
 
         str last_query
@@ -47,6 +47,8 @@ cdef class BaseProtocol(CoreProtocol):
         readonly uint64_t queries_count
 
         PreparedStatementState statement
+
+    cdef get_connection(self)
 
     cdef _get_timeout_impl(self, timeout)
     cdef _check_state(self)


### PR DESCRIPTION
Connection objects currently stay alive and open if they are not
explicitly closed or terminated.  GC won't happen to them because event
loops have a strong reference to their underlying Transport object.

By replacing a strong Connection<->Protocol reference with a weak one,
we are able to implement `Connection.__del__()` method that:

* issues a warning if a Connection object is being GCed prior
  to be explicitly closed;

* terminates the underlying Protocol and Transport, effectively closing
  the open network connection to the Postgres server.

When in asyncio debug mode (enabled by PYTHONASYNCIODEBUG env variable
or explicitly with `loop.set_debug(True)`) Connection objects save the
traceback of their origin and later use it to make the GC warning
clarer.

Addresses #323.