### PR TITLE
Group B/E/S into one TCP packet

### DIFF
--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -134,7 +134,6 @@ cdef class CoreProtocol:
     cdef _auth_password_message_md5(self, bytes salt)
 
     cdef _write(self, buf)
-    cdef inline _write_sync_message(self)
 
     cdef _read_server_messages(self)
 


### PR DESCRIPTION
* Group `Bind/Execute/Sync` into one TCP packet - less traffic, faster in processing.
* Append `Sync` to a previous command packet in all flows.
* Plus save one `memcpy()` in `_prepare` as a bonus.