### PR TITLE
Compatibility with pgbouncer with pool_mode != session

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -33,6 +33,7 @@ _ConnectionParameters = collections.namedtuple(
         'database',
         'ssl',
         'connect_timeout',
+        'session',
         'server_settings',
     ])
 
@@ -135,7 +136,7 @@ def _read_password_from_pgpass(
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                                 password, passfile, database, ssl,
-                                connect_timeout, server_settings):
+                                connect_timeout, session, server_settings):
     if host is not None and not isinstance(host, str):
         raise TypeError(
             'host argument is expected to be str, got {!r}'.format(
@@ -320,7 +321,8 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
 
     params = _ConnectionParameters(
         user=user, password=password, database=database, ssl=ssl,
-        connect_timeout=connect_timeout, server_settings=server_settings)
+        connect_timeout=connect_timeout, session=session,
+        server_settings=server_settings)
 
     return addrs, params
 
@@ -330,7 +332,7 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
                              statement_cache_size,
                              max_cached_statement_lifetime,
                              max_cacheable_statement_size,
-                             ssl, server_settings):
+                             session, ssl, server_settings):
 
     local_vars = locals()
     for var_name in {'max_cacheable_statement_size',
@@ -359,7 +361,7 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
         dsn=dsn, host=host, port=port, user=user,
         password=password, passfile=passfile, ssl=ssl,
         database=database, connect_timeout=timeout,
-        server_settings=server_settings)
+        session=session, server_settings=server_settings)
 
     config = _ClientConfiguration(
         command_timeout=command_timeout,

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -132,17 +132,9 @@ class PostgresMessage(metaclass=PostgresMessageMeta):
             hint = dct.get('hint', '')
             hint += textwrap.dedent("""\
 
-                NOTE: pgbouncer with pool_mode set to "transaction" or
-                "statement" does not support prepared statements properly.
-                You have two options:
-
-                * if you are using pgbouncer for connection pooling to a
-                  single server, switch to the connection pool functionality
-                  provided by asyncpg, it is a much better option for this
-                  purpose;
-
-                * if you have no option of avoiding the use of pgbouncer,
-                  then you must switch pgbouncer's pool_mode to "session".
+                if you are using pgbouncer with pool_mode set to "transaction"
+                or "statement", then you must initialize Connection with
+                session set to False.
             """)
 
             dct['hint'] = hint

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -104,6 +104,8 @@ cdef class CoreProtocol:
         # True - completed, False - suspended
         bint result_execute_completed
 
+    cpdef is_in_transaction(self)
+
     cdef _process__auth(self, char mtype)
     cdef _process__prepare(self, char mtype)
     cdef _process__bind_execute(self, char mtype)
@@ -143,21 +145,27 @@ cdef class CoreProtocol:
 
     cdef _ensure_connected(self)
 
+    cdef WriteBuffer _build_parse_message(self, str stmt_name, str query)
+    cdef WriteBuffer _build_describe_message(self, str stmt_name)
     cdef WriteBuffer _build_bind_message(self, str portal_name,
                                          str stmt_name,
                                          WriteBuffer bind_data)
+    cdef WriteBuffer _build_execute_message(self, str portal_name,
+                                            int32_t limit)
 
 
     cdef _connect(self)
     cdef _prepare(self, str stmt_name, str query)
-    cdef _send_bind_message(self, str portal_name, str stmt_name,
-                            WriteBuffer bind_data, int32_t limit)
-    cdef _bind_execute(self, str portal_name, str stmt_name,
-                       WriteBuffer bind_data, int32_t limit)
-    cdef _bind_execute_many(self, str portal_name, str stmt_name,
-                            object bind_data)
-    cdef _bind(self, str portal_name, str stmt_name,
-               WriteBuffer bind_data)
+    cdef _send_parse_bind_execute(self, str stmt_name, str query,
+                                  str portal_name, WriteBuffer bind_data,
+                                  int32_t limit)
+    cdef _parse_bind_execute(self, str stmt_name, str query,
+                             str portal_name, WriteBuffer bind_data,
+                             int32_t limit)
+    cdef _parse_bind_execute_many(self, str stmt_name, str query,
+                                  str portal_name, object bind_data)
+    cdef _parse_bind(self, str stmt_name, str query,
+                     str portal_name, WriteBuffer bind_data)
     cdef _execute(self, str portal_name, int32_t limit)
     cdef _close(self, str name, bint is_portal)
     cdef _simple_query(self, str query)

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -134,7 +134,6 @@ cdef class CoreProtocol:
     cdef _auth_password_message_md5(self, bytes salt)
 
     cdef _write(self, buf)
-    cdef inline _write_sync_message(self)
 
     cdef _read_server_messages(self)
 

--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -29,8 +29,14 @@ cdef class CoreProtocol:
         self._execute_iter = None
         self._execute_portal_name = None
         self._execute_stmt_name = None
+        self._execute_query = None
 
         self._reset_result()
+
+    cpdef is_in_transaction(self):
+        # PQTRANS_INTRANS = idle, within transaction block
+        # PQTRANS_INERROR = idle, within failed transaction
+        return self.xact_status in (PQTRANS_INTRANS, PQTRANS_INERROR)
 
     cdef _write(self, buf):
         self.transport.write(memoryview(buf))
@@ -265,10 +271,15 @@ cdef class CoreProtocol:
                     self.result = e
                     self._push_result()
                 else:
+                    if self.con_params.session or self.is_in_transaction():
+                        query = None
+                    else:
+                        query = self._execute_query
+
                     # Next iteration over the executemany() arg sequence
-                    self._send_bind_message(
-                        self._execute_portal_name, self._execute_stmt_name,
-                        buf, 0)
+                    self._send_parse_bind_execute(
+                        self._execute_stmt_name, query,
+                        self._execute_portal_name, buf, 0)
 
         elif mtype == b'I':
             # EmptyQueryResponse
@@ -681,6 +692,27 @@ cdef class CoreProtocol:
         if self.con_status != CONNECTION_OK:
             raise apg_exc.InternalClientError('not connected')
 
+    cdef WriteBuffer _build_parse_message(self, str stmt_name, str query):
+        cdef WriteBuffer buf
+
+        buf = WriteBuffer.new_message(b'P')
+        buf.write_str(stmt_name, self.encoding)
+        buf.write_str(query, self.encoding)
+        buf.write_int16(0)
+        buf.end_message()
+
+        return buf
+
+    cdef WriteBuffer _build_describe_message(self, str stmt_name):
+        cdef WriteBuffer buf
+
+        buf = WriteBuffer.new_message(b'D')
+        buf.write_byte(b'S')
+        buf.write_str(stmt_name, self.encoding)
+        buf.end_message()
+
+        return buf
+
     cdef WriteBuffer _build_bind_message(self, str portal_name,
                                          str stmt_name,
                                          WriteBuffer bind_data):
@@ -694,6 +726,17 @@ cdef class CoreProtocol:
         buf.write_buffer(bind_data)
 
         buf.end_message()
+        return buf
+
+    cdef WriteBuffer _build_execute_message(self, str portal_name,
+                                            int32_t limit):
+        cdef WriteBuffer buf
+
+        buf = WriteBuffer.new_message(b'E')
+        buf.write_str(portal_name, self.encoding)  # name of the portal
+        buf.write_int32(limit)  # number of rows to return; 0 - all
+        buf.end_message()
+
         return buf
 
     # API for subclasses
@@ -739,64 +782,50 @@ cdef class CoreProtocol:
         self._write(outbuf)
 
     cdef _prepare(self, str stmt_name, str query):
-        cdef:
-            WriteBuffer packet
-            WriteBuffer buf
+        cdef WriteBuffer buf
 
         self._ensure_connected()
         self._set_state(PROTOCOL_PREPARE)
 
-        buf = WriteBuffer.new_message(b'P')
-        buf.write_str(stmt_name, self.encoding)
-        buf.write_str(query, self.encoding)
-        buf.write_int16(0)
-        buf.end_message()
-        packet = buf
+        buf = self._build_parse_message(stmt_name, query)
+        buf.write_buffer(self._build_describe_message(stmt_name))
 
-        buf = WriteBuffer.new_message(b'D')
-        buf.write_byte(b'S')
-        buf.write_str(stmt_name, self.encoding)
-        buf.end_message()
-        packet.write_buffer(buf)
+        buf.write_bytes(SYNC_MESSAGE)
 
-        packet.write_bytes(SYNC_MESSAGE)
+        self._write(buf)
 
-        self._write(packet)
-
-    cdef _send_bind_message(self, str portal_name, str stmt_name,
-                            WriteBuffer bind_data, int32_t limit):
-
+    cdef _send_parse_bind_execute(self, str stmt_name, str query,
+                                  str portal_name, WriteBuffer bind_data,
+                                  int32_t limit):
         cdef:
-            WriteBuffer packet
             WriteBuffer buf
+            WriteBuffer pbuf
 
         buf = self._build_bind_message(portal_name, stmt_name, bind_data)
-        packet = buf
+        buf.write_buffer(self._build_execute_message(portal_name, limit))
 
-        buf = WriteBuffer.new_message(b'E')
-        buf.write_str(portal_name, self.encoding)  # name of the portal
-        buf.write_int32(limit)  # number of rows to return; 0 - all
-        buf.end_message()
-        packet.write_buffer(buf)
+        if query is not None:
+            pbuf = self._build_parse_message(stmt_name, query)
+            pbuf.write_buffer(buf)
+            buf = pbuf
 
-        packet.write_bytes(SYNC_MESSAGE)
+        buf.write_bytes(SYNC_MESSAGE)
 
-        self._write(packet)
+        self._write(buf)
 
-    cdef _bind_execute(self, str portal_name, str stmt_name,
-                       WriteBuffer bind_data, int32_t limit):
-
-        cdef WriteBuffer buf
+    cdef _parse_bind_execute(self, str stmt_name, str query, str portal_name,
+                             WriteBuffer bind_data, int32_t limit):
 
         self._ensure_connected()
         self._set_state(PROTOCOL_BIND_EXECUTE)
 
         self.result = []
 
-        self._send_bind_message(portal_name, stmt_name, bind_data, limit)
+        self._send_parse_bind_execute(stmt_name, query,
+                                      portal_name, bind_data, limit)
 
-    cdef _bind_execute_many(self, str portal_name, str stmt_name,
-                            object bind_data):
+    cdef _parse_bind_execute_many(self, str stmt_name, str query,
+                                  str portal_name, object bind_data):
 
         cdef WriteBuffer buf
 
@@ -808,6 +837,7 @@ cdef class CoreProtocol:
         self._execute_iter = bind_data
         self._execute_portal_name = portal_name
         self._execute_stmt_name = stmt_name
+        self._execute_query = query
 
         try:
             buf = <WriteBuffer>next(bind_data)
@@ -818,7 +848,29 @@ cdef class CoreProtocol:
             self.result = e
             self._push_result()
         else:
-            self._send_bind_message(portal_name, stmt_name, buf, 0)
+            self._send_parse_bind_execute(stmt_name, query,
+                                          portal_name, buf, 0)
+
+    cdef _parse_bind(self, str stmt_name, str query,
+                     str portal_name, WriteBuffer bind_data):
+
+        cdef:
+            WriteBuffer buf
+            WriteBuffer pbuf
+
+        self._ensure_connected()
+        self._set_state(PROTOCOL_BIND)
+
+        buf = self._build_bind_message(portal_name, stmt_name, bind_data)
+
+        if query is not None:
+            pbuf = self._build_parse_message(stmt_name, query)
+            pbuf.write_buffer(buf)
+            buf = pbuf
+
+        buf.write_bytes(SYNC_MESSAGE)
+
+        self._write(buf)
 
     cdef _execute(self, str portal_name, int32_t limit):
         cdef WriteBuffer buf
@@ -828,24 +880,7 @@ cdef class CoreProtocol:
 
         self.result = []
 
-        buf = WriteBuffer.new_message(b'E')
-        buf.write_str(portal_name, self.encoding)  # name of the portal
-        buf.write_int32(limit)  # number of rows to return; 0 - all
-        buf.end_message()
-
-        buf.write_bytes(SYNC_MESSAGE)
-
-        self._write(buf)
-
-    cdef _bind(self, str portal_name, str stmt_name,
-               WriteBuffer bind_data):
-
-        cdef WriteBuffer buf
-
-        self._ensure_connected()
-        self._set_state(PROTOCOL_BIND)
-
-        buf = self._build_bind_message(portal_name, stmt_name, bind_data)
+        buf = self._build_execute_message(portal_name, limit)
 
         buf.write_bytes(SYNC_MESSAGE)
 

--- a/asyncpg/protocol/prepared_stmt.pxd
+++ b/asyncpg/protocol/prepared_stmt.pxd
@@ -12,6 +12,8 @@ cdef class PreparedStatementState:
         readonly bint closed
         readonly int refs
 
+        public bint need_reprepare
+
         FastReadBuffer buffer
 
         list         row_desc

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -19,6 +19,7 @@ cdef class PreparedStatementState:
         self.args_codecs = self.rows_codecs = None
         self.args_num = self.cols_num = 0
         self.cols_desc = None
+        self.need_reprepare = False
         self.closed = False
         self.refs = 0
         self.buffer = FastReadBuffer.new()

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -56,8 +56,7 @@ a need to run the same query again.
 .. warning::
 
    If you are using pgbouncer with ``pool_mode`` set to ``transaction`` or
-   ``statement``, prepared statements will not work correctly.  See
-   :ref:`asyncpg-prepared-stmt-errors` for more information.
+   ``statement``, initialize Connection with session set to False.
 
 
 .. autoclass:: asyncpg.prepared_stmt.PreparedStatement()

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -56,15 +56,10 @@ already exists`` errors, you are most likely not connecting to the
 PostgreSQL server directly, but via
 `pgbouncer <https://pgbouncer.github.io/>`_.  pgbouncer, when
 in the ``"transaction"`` or ``"statement"`` pooling mode, does not support
-prepared statements.  You have two options:
-
-* if you are using pgbouncer for connection pooling to a single server,
-  switch to the :ref:`connection pool <asyncpg-connection-pool>`
-  functionality provided by asyncpg, it is a much better option for this
-  purpose;
-
-* if you have no option of avoiding the use of pgbouncer, then you need to
-  switch pgbouncer's ``pool_mode`` to ``session``.
+any features with session lifetime (including prepared statements).
+You must initialize :class:`Connection` with ``session`` set to ``False``, this
+will prevent the client from using named prepared statements and will limit it
+to use unnamed prepared statements in a transaction only.
 
 
 Why do I get ``PostgresSyntaxError`` when using ``expression IN $1``?

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -206,7 +206,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host', 123)], {
                 'user': 'user',
                 'password': 'passw',
-                'database': 'testdb'})
+                'database': 'testdb',
+                'session': True})
         },
 
         {
@@ -227,7 +228,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host2', 456)], {
                 'user': 'user2',
                 'password': 'passw2',
-                'database': 'db2'})
+                'database': 'db2',
+                'session': True})
         },
 
         {
@@ -250,7 +252,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('host2', 456)], {
                 'user': 'user2',
                 'password': 'passw2',
-                'database': 'db2'})
+                'database': 'db2',
+                'session': True})
         },
 
         {
@@ -267,7 +270,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('localhost', 5555)], {
                 'user': 'user3',
                 'password': '123123',
-                'database': 'abcdef'})
+                'database': 'abcdef',
+                'session': True})
         },
 
         {
@@ -275,7 +279,8 @@ class TestConnectParams(tb.TestCase):
             'result': ([('localhost', 5555)], {
                 'user': 'user3',
                 'password': '123123',
-                'database': 'abcdef'})
+                'database': 'abcdef',
+                'session': True})
         },
 
         {
@@ -291,7 +296,8 @@ class TestConnectParams(tb.TestCase):
                 'server_settings': {'param': '123'},
                 'user': 'me',
                 'password': 'ask',
-                'database': 'db'})
+                'database': 'db',
+                'session': True})
         },
 
         {
@@ -308,14 +314,16 @@ class TestConnectParams(tb.TestCase):
                 'server_settings': {'aa': 'bb', 'param': '123'},
                 'user': 'me',
                 'password': 'ask',
-                'database': 'db'})
+                'database': 'db',
+                'session': True})
         },
 
         {
             'dsn': 'postgresql:///dbname?host=/unix_sock/test&user=spam',
             'result': ([os.path.join('/unix_sock/test', '.s.PGSQL.5432')], {
                 'user': 'spam',
-                'database': 'dbname'})
+                'database': 'dbname',
+                'session': True})
         },
 
         {
@@ -384,7 +392,8 @@ class TestConnectParams(tb.TestCase):
             addrs, params = connect_utils._parse_connect_dsn_and_args(
                 dsn=dsn, host=host, port=port, user=user, password=password,
                 passfile=passfile, database=database, ssl=None,
-                connect_timeout=None, server_settings=server_settings)
+                connect_timeout=None, session=True,
+                server_settings=server_settings)
 
             params = {k: v for k, v in params._asdict().items()
                       if v is not None}
@@ -429,7 +438,11 @@ class TestConnectParams(tb.TestCase):
                 'host': 'abc',
                 'result': (
                     [('abc', 5432)],
-                    {'user': '__test__', 'database': '__test__'}
+                    {
+                        'user': '__test__',
+                        'database': '__test__',
+                        'session': True,
+                    }
                 )
             })
 
@@ -467,6 +480,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -483,6 +497,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -497,6 +512,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for user@abc',
                         'user': 'user',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -512,6 +528,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for localhost',
                         'user': 'user',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -529,6 +546,7 @@ class TestConnectParams(tb.TestCase):
                             'password': 'password from pgpass for localhost',
                             'user': 'user',
                             'database': 'db',
+                            'session': True,
                         }
                     )
                 })
@@ -546,6 +564,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for cde:5433',
                         'user': 'user',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -562,6 +581,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for testuser',
                         'user': 'testuser',
                         'database': 'db',
+                        'session': True,
                     }
                 )
             })
@@ -578,6 +598,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass for testdb',
                         'user': 'user',
                         'database': 'testdb',
+                        'session': True,
                     }
                 )
             })
@@ -594,6 +615,7 @@ class TestConnectParams(tb.TestCase):
                         'password': 'password from pgpass with escapes',
                         'user': R'test\\',
                         'database': R'test\:db',
+                        'session': True,
                     }
                 )
             })
@@ -621,6 +643,7 @@ class TestConnectParams(tb.TestCase):
                         {
                             'user': 'user',
                             'database': 'db',
+                            'session': True,
                         }
                     )
                 })
@@ -641,6 +664,7 @@ class TestConnectParams(tb.TestCase):
                         {
                             'user': 'user',
                             'database': 'db',
+                            'session': True,
                         }
                     )
                 })
@@ -657,6 +681,7 @@ class TestConnectParams(tb.TestCase):
                 {
                     'user': 'user',
                     'database': 'db',
+                    'session': True,
                 }
             )
         })


### PR DESCRIPTION
Add `session` parameter to `connection()` with default value `True`.
When set to `False` the client will limit usage of prepared statements
to unnamed in a transaction only.

As a side effect handling of unnamed prepared statements improved
irrespective of `session` value - they are automatically reprepared
if something invalidating them occurs.