### PR TITLE
Allow mappings as composite type input

### DIFF
--- a/asyncpg/protocol/codecs/array.pyx
+++ b/asyncpg/protocol/codecs/array.pyx
@@ -5,7 +5,9 @@
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
 
-from collections.abc import Iterable as IterableABC, Sized as SizedABC
+from collections.abc import (Iterable as IterableABC,
+                             Mapping as MappingABC,
+                             Sized as SizedABC)
 
 from asyncpg import exceptions
 
@@ -36,7 +38,8 @@ cdef inline _is_array_iterable(object obj):
     return (
         isinstance(obj, IterableABC) and
         isinstance(obj, SizedABC) and
-        not _is_trivial_container(obj)
+        not _is_trivial_container(obj) and
+        not isinstance(obj, MappingABC)
     )
 
 

--- a/asyncpg/protocol/codecs/base.pxd
+++ b/asyncpg/protocol/codecs/base.pxd
@@ -67,6 +67,7 @@ cdef class Codec:
         # composite types
         tuple           element_type_oids
         object          element_names
+        object          record_desc
         list            element_codecs
 
         # Pointers to actual encoder/decoder functions for this codec

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,7 +76,8 @@ The table below shows the correspondence between PostgreSQL and Python types.
 | ``anyrange``         | :class:`asyncpg.Range <asyncpg.types.Range>`        |
 +----------------------+-----------------------------------------------------+
 | ``record``           | :class:`asyncpg.Record`,                            |
-|                      | :class:`tuple <python:tuple>`                       |
+|                      | :class:`tuple <python:tuple>`,                      |
+|                      | :class:`Mapping <python:collections.abc.Mapping>`   |
 +----------------------+-----------------------------------------------------+
 | ``bit``, ``varbit``  | :class:`asyncpg.BitString <asyncpg.types.BitString>`|
 +----------------------+-----------------------------------------------------+


### PR DESCRIPTION
This allows asyncpg to take an arbitrary mapping as input for composite
types, as long as the keys match composite type fields.
This allows removing some tedium when handling complex composite types.

Fixes: #349.