### PR TITLE
Make ReadBuffer interface more robust

### DIFF
--- a/asyncpg/protocol/buffer.pxd
+++ b/asyncpg/protocol/buffer.pxd
@@ -105,13 +105,14 @@ cdef class ReadBuffer:
     cdef inline int32_t read_int32(self) except? -1
     cdef inline int16_t read_int16(self) except? -1
     cdef inline read_cstr(self)
-    cdef int32_t has_message(self) except -1
-    cdef inline int32_t has_message_type(self, char mtype) except -1
+    cdef int32_t take_message(self) except -1
+    cdef inline int32_t take_message_type(self, char mtype) except -1
+    cdef int32_t put_message(self) except -1
     cdef inline const char* try_consume_message(self, ssize_t* len)
     cdef Memory consume_message(self)
     cdef bytearray consume_messages(self, char mtype)
-    cdef discard_message(self)
-    cdef inline _discard_message(self)
+    cdef finish_message(self)
+    cdef inline _finish_message(self)
     cdef inline char get_message_type(self)
     cdef inline int32_t get_message_length(self)
 


### PR DESCRIPTION
The current ReadBuffer interface is somewhat error prone.  There is no
way to "peek" at the next message, so various subprotocols that have
nested message processing loops have to resort to the `_skip_discard`
kludge on the protocol to inform the main loop that it shouldn't skip
over to the next message because the subprotocol already read too much.

Fix this by adding a way to iterate over the messages without
over-reading, and a way to "put" a message back into the buffer when
necessary.  This also renames `has_message()` to `take_message()` to
make it clear that it changes the buffer state.