### PR TITLE
Check for .flake8 after importing flake8

### DIFF
--- a/tests/test__sourcecode.py
+++ b/tests/test__sourcecode.py
@@ -17,15 +17,15 @@ def find_root():
 class TestFlake8(unittest.TestCase):
 
     def test_flake8(self):
-        root_path = find_root()
-        config_path = os.path.join(root_path, '.flake8')
-        if not os.path.exists(config_path):
-            raise RuntimeError('could not locate .flake8 file')
-
         try:
             import flake8  # NoQA
         except ImportError:
             raise unittest.SkipTest('flake8 module is missing')
+
+        root_path = find_root()
+        config_path = os.path.join(root_path, '.flake8')
+        if not os.path.exists(config_path):
+            raise RuntimeError('could not locate .flake8 file')
 
         try:
             subprocess.run(


### PR DESCRIPTION
This way, tests won't fail if both the flake8 module and the .flake8 file are missing.