### PR TITLE
fix timezone type label in docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -116,13 +116,13 @@ The table below shows the correspondence between PostgreSQL and Python types.
 |                      | <python:datetime.time>`                             |
 +----------------------+-----------------------------------------------------+
 | ``time with          | offset-aware :class:`datetime.time \                |
-| timezone``           | <python:datetime.time>`                             |
+| time zone``          | <python:datetime.time>`                             |
 +----------------------+-----------------------------------------------------+
 | ``timestamp``        | offset-naïve :class:`datetime.datetime \            |
 |                      | <python:datetime.datetime>`                         |
 +----------------------+-----------------------------------------------------+
 | ``timestamp with     | offset-aware :class:`datetime.datetime \            |
-| timezone``           | <python:datetime.datetime>`                         |
+| time zone``          | <python:datetime.datetime>`                         |
 +----------------------+-----------------------------------------------------+
 | ``interval``         | :class:`datetime.timedelta \                        |
 |                      | <python:datetime.timedelta>`                        |


### PR DESCRIPTION
This merge request updates the docs to fix a minor typo in the PostgreSQL Type definition from ``timestamp with timezone`` to ``timestamp with time zone``.

While attempting to try out ``asyncpg`` I created a function to create a table. I cut and pasted PostgeSQL type definitions from the asyncpg [docs](https://magicstack.github.io/asyncpg/current/usage.html) to help define my table. When I ran the function I observed the error below.
```
asyncpg.exceptions.PostgresSyntaxError: syntax error at or near "with"
```

PostgreSQL reported a similar issue:
```
2019-03-10 06:18:09.398 UTC [74] ERROR:  syntax error at or near "with" at character 141
2019-03-10 06:18:09.398 UTC [74] STATEMENT:  
	                CREATE TABLE IF NOT EXISTS messages(
	                    id bigserial PRIMARY KEY,
	                    timestamp timestamp with timezone,
	                    icao varchar(6),
	                    ... lots more fields
	                )
```
I found that the timestamp definition I copied from the asyncpg docs was incorrect. The asyncpg docs list the type as ``timestamp with timezone`` whereas the PostgreSQL [docs](https://www.postgresql.org/docs/9.1/datatype-datetime.html) define it as ``timestamp [ (p) ] with time zone``. There is a space between the words time and zone. Making this change in my create table function resolved the issue.
