### PR TITLE
Restore support for usernames containing '@' in connection strings.

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -211,7 +211,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
 
         if not host and parsed.netloc:
             if '@' in parsed.netloc:
-                auth, _, hostspec = parsed.netloc.partition('@')
+                auth, _, hostspec = parsed.netloc.rpartition('@')
             else:
                 hostspec = parsed.netloc
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -402,6 +402,14 @@ class TestConnectParams(tb.TestCase):
                 }
             )
         },
+
+        {
+            'dsn': 'postgresql://some@user@host1/db',
+            'result': ([('host1', 5432)], {
+                'database': 'db',
+                'user': 'some@user',
+            })
+        },
     ]
 
     @contextlib.contextmanager


### PR DESCRIPTION
Prior to version 0.18.0 it was possible to have an '@' in a connection
string, but that feature got lost when the parsing code was rewritten to
support multiple host addresses.