### PR TITLE
Fix assertion fail on copy_records_to_table

### DIFF
--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -434,7 +434,7 @@ cdef class CoreProtocol:
             Py_buffer *pybuf
 
         mview = cpythonx.PyMemoryView_GetContiguous(
-            data, cpython.PyBUF_SIMPLE, b'C')
+            data, cpython.PyBUF_READ, b'C')
 
         try:
             pybuf = cpythonx.PyMemoryView_GET_BUFFER(mview)


### PR DESCRIPTION
Current implementation misuses `buffertype` argument of `PyMemoryView_GetContiguous()` function.
One must pass `PyBUF_READ` or `PyBUF_WRITE` since other options lead to assertion fire (in python debug mode).