### PR TITLE
fixes leaking connections in _connect_addr

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -660,4 +660,4 @@ def _close_leaked_connection(fut):
         if tr:
             tr.close()
     except asyncio.CancelledError:
-        pass # hide the exception
+        pass  # hide the exception


### PR DESCRIPTION
**Short summary**
I've discovered that inner coroutine passed to `asyncio.wait_for` function may not be canceled even though CancelledError is raised.

Since there is no references to protocol or transport objects – that connection will leak forever.

I've found rather dirty way to deal with it. How can it be improved?

**Detailed information can be found here:**
https://bugs.python.org/issue37658
https://github.com/MagicStack/asyncpg/issues/467
https://stackoverflow.com/questions/57163025/socket-leak-with-wait-for-in-asyncio-with-python3-6-and-python3-7