### PR TITLE
Updated documentation for building from source

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,9 @@ the ``ASYNCPG_DEBUG`` environment variable when building:
 Running tests
 -------------
 
+
+If you want to run tests you must have PostgreSQL installed.
+
 To execute the testsuite run:
 
 .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,6 +25,7 @@ Building from source
 
 If you want to build **asyncpg** from a Git checkout you will need:
 
+  * To have cloned the repo with `--recurse-submodules`.
   * A working C compiler.
   * CPython header files.  These can usually be obtained by installing
     the relevant Python development package: **python3-dev** on Debian/Ubuntu,


### PR DESCRIPTION
Because the Cython files are kept in a git submodule, you must `git clone --recurse-submodules` to be able to build from source.