### PR TITLE
Connection as context manager

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -50,6 +50,12 @@ class Connection(metaclass=ConnectionMeta):
                  '_log_listeners', '_cancellations', '_source_traceback',
                  '__weakref__')
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        await self.close()
+
     def __init__(self, protocol, transport, loop,
                  addr: (str, int) or str,
                  config: connect_utils._ClientConfiguration,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,9 @@ the ``ASYNCPG_DEBUG`` environment variable when building:
 Running tests
 -------------
 
+
+If you want to run tests you must have PostgreSQL installed.
+
 To execute the testsuite run:
 
 .. code-block:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,6 +25,7 @@ Building from source
 
 If you want to build **asyncpg** from a Git checkout you will need:
 
+  * To have cloned the repo with `--recurse-submodules`.
   * A working C compiler.
   * CPython header files.  These can usually be obtained by installing
     the relevant Python development package: **python3-dev** on Debian/Ubuntu,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,6 +47,15 @@ which provides methods to run queries and manage transactions.
     asyncio.get_event_loop().run_until_complete(main())
 
 
+The :class:`Connection <asyncpg.connection.Connection>` can also be used as an
+asynchronous context manager, which will take care of closing the connection
+for you:
+
+-- code-block:: python
+    async with asyncpg.connect('postgresql://postgres@localhost/test') as conn:
+        row = await conn.fetchrow(
+            'SELECT * FROM users WHERE name = $1', 'Bob')
+    # The connection is now closed
 
 .. note::
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1035,6 +1035,16 @@ class TestConnection(tb.ConnectedTestCase):
                 host='/tmp',
                 ssl=ssl_context)
 
+    async def test_connection_as_context_manager(self):
+        conn_spec = self.get_connection_spec()
+        async with await asyncpg.connect(
+            port=conn_spec.get('port'),
+            database=conn_spec.get('database'),
+            user=conn_spec.get('user'),
+            loop=self.loop) as con:
+            self.assertEqual(await con.fetchval('SELECT 42'), 42)
+
+
     async def test_connection_implicit_host(self):
         conn_spec = self.get_connection_spec()
         con = await asyncpg.connect(


### PR DESCRIPTION
This PR enables `asyncpg.connect` to be used as a context manager:

We can now (optionally) do:

```
async with asynpg.connection(...) as con:
```

The connection will be closed when the with block ends. This means the user no longer has to remember to `await con.close()`. The docs have been updated. A test has been added which ensures the connection still works when used in this way.