### PR TITLE
Improve pool documentation examples

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -802,9 +802,11 @@ def create_pool(dsn=None, *,
         async with asyncpg.create_pool(user='postgres',
                                        command_timeout=60) as pool:
             async with pool.acquire() as con:
-                await con.execute('CREATE TABLE \
-                        names (id serial PRIMARY KEY, \
-                        name VARCHAR (255) NOT NULL)')
+                await con.execute("""
+CREATE TABLE names (
+    id serial PRIMARY KEY,
+    name VARCHAR (255) NOT NULL)
+                """)
                 await con.fetch('SELECT 1')
 
     Or directly with ``await`` (not recommended):

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -793,10 +793,19 @@ def create_pool(dsn=None, *,
 
         async with asyncpg.create_pool(user='postgres',
                                        command_timeout=60) as pool:
+            await pool.fetch('SELECT 1')
+
+    Or to perform multiple operations on a single connection:
+
+    .. code-block:: python
+
+        async with asyncpg.create_pool(user='postgres',
+                                       command_timeout=60) as pool:
             async with pool.acquire() as con:
+                await con.execute('CREATE TABLE names (id serial PRIMARY KEY, name VARCHAR (255) NOT NULL)')
                 await con.fetch('SELECT 1')
 
-    Or directly with ``await``:
+    Or directly with ``await`` (not recommended):
 
     .. code-block:: python
 

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -811,11 +811,11 @@ def create_pool(dsn=None, *,
         async with asyncpg.create_pool(user='postgres',
                                        command_timeout=60) as pool:
             async with pool.acquire() as con:
-                await con.execute("""
-CREATE TABLE names (
-    id serial PRIMARY KEY,
-    name VARCHAR (255) NOT NULL)
-                """)
+                await con.execute('''
+                   CREATE TABLE names (
+                      id serial PRIMARY KEY,
+                      name VARCHAR (255) NOT NULL)
+                ''')
                 await con.fetch('SELECT 1')
 
     Or directly with ``await`` (not recommended):

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -802,7 +802,9 @@ def create_pool(dsn=None, *,
         async with asyncpg.create_pool(user='postgres',
                                        command_timeout=60) as pool:
             async with pool.acquire() as con:
-                await con.execute('CREATE TABLE names (id serial PRIMARY KEY, name VARCHAR (255) NOT NULL)')
+                await con.execute('CREATE TABLE \
+                        names (id serial PRIMARY KEY, \
+                        name VARCHAR (255) NOT NULL)')
                 await con.fetch('SELECT 1')
 
     Or directly with ``await`` (not recommended):


### PR DESCRIPTION
I think pool documentation should recommend the safest approaches first (i.e. with the fewest possible mistakes), and discourage lower-level approach.