### PR TITLE
Change interaction with server to only send one SYNC message (Pgbouncer support)

### DIFF
--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -142,7 +142,8 @@ class PostgresMessage(metaclass=PostgresMessageMeta):
                   purpose;
 
                 * if you have no option of avoiding the use of pgbouncer,
-                  then you must switch pgbouncer's pool_mode to "session".
+                  then you can set statement_cache_size to 0 when creating
+                  the asyncpg connection object.
             """)
 
             dct['hint'] = hint

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -588,6 +588,13 @@ cdef class BaseProtocol(CoreProtocol):
             })
             self.abort()
 
+        if self.state == PROTOCOL_PREPARE:
+            # we need to send a SYNC to server if we cancel during the PREPARE phase
+            # because the PREPARE sequence does not send a SYNC itself.
+            # we cannot send this extra SYNC if we are not in PREPARE phase,
+            # because then we would issue two SYNCs and we would get two ReadyForQuery
+            # replies, which our current state machine implementation cannot handle
+            self._write(SYNC_MESSAGE)
         self._set_state(PROTOCOL_CANCELLED)
 
     def _on_timeout(self, fut):


### PR DESCRIPTION
This is a simple implementation of PgBouncer support for asyncpg. It doesn't have any detection features, but at least changes asyncpg behavior in such a way that using pgbouncer is possible. 
I implemented part of your suggestions as described in https://github.com/MagicStack/asyncpg/pull/348#issuecomment-416058033 , but in a simpler way. I just got rid of the explicit SYNC after a parse/describe and changed it to a FLUSH. This should work regardless of the setting of statement_cache_size and whether or not it's pgbouncer or direct postgres connection.
With this, if the user wants to use PgBouncer, he'll still have to set statement_cache_size to 0, however once he does that, everything will work as expected.

Please let me know if this solution is acceptable to merge.