### PR TITLE
Handle IP values with prefix in "inet" type as IPvXInterface

### DIFF
--- a/asyncpg/protocol/codecs/pgproto.pyx
+++ b/asyncpg/protocol/codecs/pgproto.pyx
@@ -382,12 +382,12 @@ cdef init_numeric_codecs():
 cdef init_network_codecs():
     register_core_codec(CIDROID,
                         <encode_func>pgproto.cidr_encode,
-                        <decode_func>pgproto.net_decode,
+                        <decode_func>pgproto.cidr_decode,
                         PG_FORMAT_BINARY)
 
     register_core_codec(INETOID,
                         <encode_func>pgproto.inet_encode,
-                        <decode_func>pgproto.net_decode,
+                        <decode_func>pgproto.inet_decode,
                         PG_FORMAT_BINARY)
 
     register_core_codec(MACADDROID,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,14 +97,14 @@ The table below shows the correspondence between PostgreSQL and Python types.
 |                      | :class:`ipaddress.IPv6Network\                      |
 |                      | <python:ipaddress.IPv6Network>`                     |
 +----------------------+-----------------------------------------------------+
-| ``inet``             | :class:`ipaddress.IPv4Network\                      |
-|                      | <python:ipaddress.IPv4Network>`,                    |
-|                      | :class:`ipaddress.IPv6Network\                      |
-|                      | <python:ipaddress.IPv6Network>`,                    |
+| ``inet``             | :class:`ipaddress.IPv4Interface\                    |
+|                      | <python:ipaddress.IPv4Interface>`,                  |
+|                      | :class:`ipaddress.IPv6Interface\                    |
+|                      | <python:ipaddress.IPv6Interface>`,                  |
 |                      | :class:`ipaddress.IPv4Address\                      |
 |                      | <python:ipaddress.IPv4Address>`,                    |
 |                      | :class:`ipaddress.IPv6Address\                      |
-|                      | <python:ipaddress.IPv6Address>`                     |
+|                      | <python:ipaddress.IPv6Address>` [#f1]_              |
 +----------------------+-----------------------------------------------------+
 | ``macaddr``          | :class:`str <python:str>`                           |
 +----------------------+-----------------------------------------------------+
@@ -127,7 +127,7 @@ The table below shows the correspondence between PostgreSQL and Python types.
 | ``interval``         | :class:`datetime.timedelta \                        |
 |                      | <python:datetime.timedelta>`                        |
 +----------------------+-----------------------------------------------------+
-| ``float``,           | :class:`float <python:float>` [#f1]_                |
+| ``float``,           | :class:`float <python:float>` [#f2]_                |
 | ``double precision`` |                                                     |
 +----------------------+-----------------------------------------------------+
 | ``smallint``,        | :class:`int <python:int>`                           |
@@ -158,7 +158,10 @@ The table below shows the correspondence between PostgreSQL and Python types.
 
 All other types are encoded and decoded as text by default.
 
-.. [#f1] Inexact single-precision ``float`` values may have a different
+.. [#f1] Prior to version 0.20.0, asyncpg erroneously treated ``inet`` values
+         with prefix as ``IPvXNetwork`` instead of ``IPvXInterface``.
+
+.. [#f2] Inexact single-precision ``float`` values may have a different
          representation when decoded into a Python float.  This is inherent
          to the implementation of limited-precision floating point types.
          If you need the decimal representation to match, cast the expression

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -341,9 +341,12 @@ type_samples = [
         ipaddress.IPv6Address('ffff' + ':ffff' * 7),
         ipaddress.IPv6Address('::1'),
         ipaddress.IPv6Address('::'),
+        ipaddress.IPv4Interface('10.0.0.1/30'),
+        ipaddress.IPv4Interface('0.0.0.0/0'),
+        ipaddress.IPv4Interface('255.255.255.255/31'),
         dict(
             input='127.0.0.0/8',
-            output=ipaddress.IPv4Network('127.0.0.0/8')),
+            output=ipaddress.IPv4Interface('127.0.0.0/8')),
         dict(
             input='127.0.0.1/32',
             output=ipaddress.IPv4Address('127.0.0.1')),
@@ -358,7 +361,7 @@ type_samples = [
             textoutput='10.11.12.13/32'
         ),
         dict(
-            input=ipaddress.IPv4Network('10.11.12.13'),
+            input=ipaddress.IPv4Interface('10.11.12.13'),
             textoutput='10.11.12.13/32'
         ),
         dict(
@@ -366,11 +369,8 @@ type_samples = [
             output=ipaddress.IPv4Address('10.11.12.13'),
         ),
         dict(
-            # Non-zero address bits after the network prefix are permitted
-            # by postgres, but are invalid in Python
-            # (and zeroed out by supernet()).
             textinput='10.11.12.13/0',
-            output=ipaddress.IPv4Network('0.0.0.0/0'),
+            output=ipaddress.IPv4Interface('10.11.12.13/0'),
         ),
     ]),
     ('macaddr', 'macaddr', [


### PR DESCRIPTION
Currently we treat values with network prefix in `inet` values
as `IPvXNetwork`, instead of `IPvXInterface` which is wrong.

Fixes: #497