### PR TITLE
Fix usage documentation for hstore

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -320,8 +320,8 @@ be registered on a connection using :meth:`Connection.set_builtin_type_codec()
         # Assuming the hstore extension exists in the public schema.
         await conn.set_builtin_type_codec(
             'hstore', codec_name='pg_contrib.hstore')
-        result = await conn.fetchval("SELECT 'a=>1,b=>2'::hstore")
-        assert result == {'a': '1', 'b': '2'}
+        result = await conn.fetchval("SELECT 'a=>1,b=>2,c=>NULL'::hstore")
+        assert result == {'a': '1', 'b': '2', 'c': None}
 
     asyncio.get_event_loop().run_until_complete(run())
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -321,7 +321,7 @@ be registered on a connection using :meth:`Connection.set_builtin_type_codec()
         await conn.set_builtin_type_codec(
             'hstore', codec_name='pg_contrib.hstore')
         result = await conn.fetchval("SELECT 'a=>1,b=>2'::hstore")
-        assert result == {'a': 1, 'b': 2}
+        assert result == {'a': '1', 'b': '2'}
 
     asyncio.get_event_loop().run_until_complete(run())
 


### PR DESCRIPTION
Previously the usage documentation suggested that the integer values in the hstore values would be converted from strings into ints. This is not the case, as all values are returned as string or None: https://github.com/MagicStack/py-pgproto/blob/e9391d4c8615c73291bc2fc77a3e6efb484bcbd0/codecs/hstore.pyx#L66-L69