### PR TITLE
add support for connection closed listeners

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -185,11 +185,16 @@ class Connection(metaclass=ConnectionMeta):
         :param callable callback:
             A callable receiving one argument:
             **connection**: a Connection the callback is registered with.
+
+        .. versionadded:: 0.21.0
         """
         self._close_listeners.add(callback)
 
     def remove_close_listener(self, callback):
-        """Remove a listening callback for the connection closing."""
+        """Remove a listening callback for the connection closing.
+
+        .. versionadded:: 0.21.0
+        """
         self._close_listeners.discard(callback)
 
     def get_server_pid(self):

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -46,7 +46,7 @@ class Connection(metaclass=ConnectionMeta):
                  '_listeners', '_server_version', '_server_caps',
                  '_intro_query', '_reset_query', '_proxy',
                  '_stmt_exclusive_section', '_config', '_params', '_addr',
-                 '_log_listeners', '_close_listeners', '_cancellations',
+                 '_log_listeners', '_termination_listeners', '_cancellations',
                  '_source_traceback', '__weakref__')
 
     def __init__(self, protocol, transport, loop,
@@ -78,7 +78,7 @@ class Connection(metaclass=ConnectionMeta):
         self._listeners = {}
         self._log_listeners = set()
         self._cancellations = set()
-        self._close_listeners = set()
+        self._termination_listeners = set()
 
         settings = self._protocol.get_settings()
         ver_string = settings.server_version
@@ -179,8 +179,8 @@ class Connection(metaclass=ConnectionMeta):
         """
         self._log_listeners.discard(callback)
 
-    def add_close_listener(self, callback):
-        """Add a listener that will be called when the the connection is closing.
+    def add_termination_listener(self, callback):
+        """Add a listener that will be called when the connection is closed.
 
         :param callable callback:
             A callable receiving one argument:
@@ -188,14 +188,18 @@ class Connection(metaclass=ConnectionMeta):
 
         .. versionadded:: 0.21.0
         """
-        self._close_listeners.add(callback)
+        self._termination_listeners.add(callback)
 
-    def remove_close_listener(self, callback):
-        """Remove a listening callback for the connection closing.
+    def remove_termination_listener(self, callback):
+        """Remove a listening callback for connection termination.
+
+        :param callable callback:
+            The callable that was passed to
+            :meth:`Connection.add_termination_listener`.
 
         .. versionadded:: 0.21.0
         """
-        self._close_listeners.discard(callback)
+        self._termination_listeners.discard(callback)
 
     def get_server_pid(self):
         """Return the PID of the Postgres server the connection is bound to."""
@@ -1139,7 +1143,7 @@ class Connection(metaclass=ConnectionMeta):
         self._protocol = None
 
     def _cleanup(self):
-        self._call_close_listeners()
+        self._call_termination_listeners()
         # Free the resources associated with this connection.
         # This must be called when a connection is terminated.
 
@@ -1257,22 +1261,24 @@ class Connection(metaclass=ConnectionMeta):
                 'exception': ex
             })
 
-    def _call_close_listeners(self):
-        if not self._close_listeners:
+    def _call_termination_listeners(self):
+        if not self._termination_listeners:
             return
 
         con_ref = self._unwrap()
-        for cb in self._close_listeners:
+        for cb in self._termination_listeners:
             try:
                 cb(con_ref)
             except Exception as ex:
                 self._loop.call_exception_handler({
-                    'message': 'Unhandled exception in asyncpg connection '
-                               'connection closed callback {!r}'.format(cb),
+                    'message': (
+                        'Unhandled exception in asyncpg connection '
+                        'termination listener callback {!r}'.format(cb)
+                    ),
                     'exception': ex
                 })
 
-        self._close_listeners.clear()
+        self._termination_listeners.clear()
 
     def _process_notification(self, pid, channel, payload):
         if channel not in self._listeners:

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -283,9 +283,9 @@ class TestLogListeners(tb.ConnectedTestCase):
     platform.system() == 'Windows' and
     sys.version_info >= (3, 8),
     'not compatible with ProactorEventLoop which is default in Python 3.8')
-class TestConnectionCloseListener(tb.ProxiedClusterTestCase):
+class TestConnectionTerminationListener(tb.ProxiedClusterTestCase):
 
-    async def test_connection_close_callback_called_on_remote(self):
+    async def test_connection_termination_callback_called_on_remote(self):
 
         called = False
 
@@ -294,7 +294,7 @@ class TestConnectionCloseListener(tb.ProxiedClusterTestCase):
             called = True
 
         con = await self.connect()
-        con.add_close_listener(close_cb)
+        con.add_termination_listener(close_cb)
         self.proxy.close_all_connections()
         try:
             await con.fetchval('SELECT 1')
@@ -302,7 +302,7 @@ class TestConnectionCloseListener(tb.ProxiedClusterTestCase):
             pass
         self.assertTrue(called)
 
-    async def test_connection_close_callback_called_on_local(self):
+    async def test_connection_termination_callback_called_on_local(self):
 
         called = False
 
@@ -311,6 +311,6 @@ class TestConnectionCloseListener(tb.ProxiedClusterTestCase):
             called = True
 
         con = await self.connect()
-        con.add_close_listener(close_cb)
+        con.add_termination_listener(close_cb)
         await con.close()
         self.assertTrue(called)

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -6,6 +6,10 @@
 
 
 import asyncio
+import os
+import platform
+import sys
+import unittest
 
 from asyncpg import _testbase as tb
 from asyncpg import exceptions
@@ -272,3 +276,41 @@ class TestLogListeners(tb.ConnectedTestCase):
                         pass
 
                     con.add_log_listener(listener1)
+
+
+@unittest.skipIf(os.environ.get('PGHOST'), 'using remote cluster for testing')
+@unittest.skipIf(
+    platform.system() == 'Windows' and
+    sys.version_info >= (3, 8),
+    'not compatible with ProactorEventLoop which is default in Python 3.8')
+class TestConnectionCloseListener(tb.ProxiedClusterTestCase):
+
+    async def test_connection_close_callback_called_on_remote(self):
+
+        called = False
+
+        def close_cb(con):
+            nonlocal called
+            called = True
+
+        con = await self.connect()
+        con.add_close_listener(close_cb)
+        self.proxy.close_all_connections()
+        try:
+            await con.fetchval('SELECT 1')
+        except Exception:
+            pass
+        self.assertTrue(called)
+
+    async def test_connection_close_callback_called_on_local(self):
+
+        called = False
+
+        def close_cb(con):
+            nonlocal called
+            called = True
+
+        con = await self.connect()
+        con.add_close_listener(close_cb)
+        await con.close()
+        self.assertTrue(called)


### PR DESCRIPTION
https://github.com/MagicStack/asyncpg/issues/421#issuecomment-475663253

- I'm not sure that the API is what I want. It's called a "cleanup listener" internally and a "close listener" externally.
- I don't know how to add tests for this.

Other than that, how does this look? The following code demonstrates the functionality. It prints True after a postgres server restart, then exits:

```py
#!/usr/bin/env python3

import asyncpg
import asyncio

async def amain():
	conn = await asyncpg.connect()
	cleanup_ran = False
	def close_listener(_):
		nonlocal cleanup_ran
		cleanup_ran = True
	conn.add_close_listener(close_listener)
	while await asyncio.sleep(1, True):
		if conn.is_closed():
			print(cleanup_ran)
			break

if __name__ == '__main__':
	asyncio.run(amain())
```