### PR TITLE
Ensure pool connection is released in acquire when cancelled

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -614,20 +614,19 @@ class Pool:
         self._check_init()
 
         acquire_fut = asyncio.ensure_future(_acquire_impl())
-        if timeout is None:
-            return await acquire_fut
-        else:
-            try:
-                return await asyncio.wait_for(
-                    acquire_fut, timeout=timeout)
-            except asyncio.CancelledError:
-                # Ensure connection is marked as not in use.
-                # The cancellation may have raced the acquire, leading
-                # to the acquire completing but the wait_for to be
-                # cancelled.
-                # See: https://bugs.python.org/issue37658
-                acquire_fut.add_done_callback(_release_leaked_connection)
-                raise
+        try:
+            # Calling wait_for with timeout=None will shortcut to run without
+            # timeout
+            return await asyncio.wait_for(
+                acquire_fut, timeout=timeout)
+        except asyncio.CancelledError:
+            # Ensure connection is marked as not in use.
+            # The cancellation may have raced the acquire, leading
+            # to the acquire completing but the wait_for to be
+            # cancelled.
+            # See: https://bugs.python.org/issue37658
+            acquire_fut.add_done_callback(_release_leaked_connection)
+            raise
 
     async def release(self, connection, *, timeout=None):
         """Release a database connection back to the pool.


### PR DESCRIPTION
Closes #547 and possibly #467 

When `wait_for` is cancelled, there is a chance that the waited task has already been completed, leaving the connection looking like it is in use. This fix ensures that the connection is returned to the pool in this situation.

A similar bug was fixed in #468, also with `wait_for`. The python issue was https://bugs.python.org/issue37658, although this is arguably not a solvable bug in Python itself as it can't know how to undo a completed task.