### PR TITLE
Fix Connection class _copy_in private method

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -813,7 +813,7 @@ class Connection(metaclass=ConnectionMeta):
 
         if path is not None:
             # a path
-            f = await run_in_executor(None, open, path, 'wb')
+            f = await run_in_executor(None, open, path, 'rb')
             opened_by_us = True
         elif hasattr(source, 'read'):
             # file-like

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -582,6 +582,47 @@ class TestCopyTo(tb.ConnectedTestCase):
         finally:
             await self.con.execute('DROP TABLE copytab')
 
+    async def test_copy_to_table_from_file_path(self):
+        await self.con.execute('''
+            CREATE TABLE copytab(a text, "b~" text, i int);
+        ''')
+
+        with tempfile.NamedTemporaryFile() as f:
+            try:
+                f.write(
+                    '\n'.join([
+                        'a1\tb1\t1',
+                        'a2\tb2\t2',
+                        'a3\tb3\t3',
+                        'a4\tb4\t4',
+                        'a5\tb5\t5',
+                        '*\t\\N\t\\N',
+                        ''
+                    ]).encode('utf-8')
+                )
+                f.seek(0)
+
+                res = await self.con.copy_to_table('copytab', source=f.name)
+                self.assertEqual(res, 'COPY 6')
+
+                output = await self.con.fetch("""
+                    SELECT * FROM copytab ORDER BY a
+                """)
+                self.assertEqual(
+                    output,
+                    [
+                        ('*', None, None),
+                        ('a1', 'b1', 1),
+                        ('a2', 'b2', 2),
+                        ('a3', 'b3', 3),
+                        ('a4', 'b4', 4),
+                        ('a5', 'b5', 5),
+                    ]
+                )
+
+            finally:
+                await self.con.execute('DROP TABLE public.copytab')
+
     async def test_copy_records_to_table_1(self):
         await self.con.execute('''
             CREATE TABLE copytab(a text, b int, c timestamptz);


### PR DESCRIPTION
I've found an issue in `Connection.copy_to_table()` method with a path-like `source` argument. The following code throws exception `io.UnsupportedOperation: read`:
```python
import asyncio
import asyncpg

async def main():
    conn = await asyncpg.connect(connection_string)
    await conn.execute('CREATE TABLE test_table(a text, "b~" text, i int);')
    await conn.copy_to_table('test_table', source=filename)
    
filename = 'table_content'
f = open(filename, 'wb')
f.write(
    '\n'.join([
        'a1\tb1\t1',
        'a2\tb2\t2',
        'a3\tb3\t3',
        'a4\tb4\t4',
        'a5\tb5\t5',
        ''
    ]).encode('utf-8')
)
f.close()

asyncio.run(main())
```

It looks like `Connection._copy_in()` method opens file in a wrong mode (`wb` instead of `rb`).
So this fix:
 * Change file opening mode to `rb`;
 * Add test case for `Connection.copy_to_table()` method with a path-like source.