### PR TITLE
Make PoolAcquireContext return a Connection type

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -767,7 +767,7 @@ class PoolAcquireContext:
         self.connection = None
         self.done = False
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> connection.Connection:
         if self.connection is not None or self.done:
             raise exceptions.InterfaceError('a connection is already acquired')
         self.connection = await self.pool._acquire(self.timeout)


### PR DESCRIPTION
`__aenter__` should be defined to return a `Connection` type. This will help IDEs to properly help suggesting methods when using with `pool.acquire() as con`