### PR TITLE
Allow using custom Record class

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E402,E731,W504,E252
+ignore = E402,E731,W503,W504,E252
 exclude = .git,__pycache__,build,dist,.eggs,.github,.local

--- a/asyncpg/_testbase/__init__.py
+++ b/asyncpg/_testbase/__init__.py
@@ -19,6 +19,7 @@ import traceback
 import unittest
 
 
+import asyncpg
 from asyncpg import cluster as pg_cluster
 from asyncpg import connection as pg_connection
 from asyncpg import pool as pg_pool
@@ -266,6 +267,7 @@ def create_pool(dsn=None, *,
                 loop=None,
                 pool_class=pg_pool.Pool,
                 connection_class=pg_connection.Connection,
+                record_class=asyncpg.Record,
                 **connect_kwargs):
     return pool_class(
         dsn,
@@ -273,6 +275,7 @@ def create_pool(dsn=None, *,
         max_queries=max_queries, loop=loop, setup=setup, init=init,
         max_inactive_connection_lifetime=max_inactive_connection_lifetime,
         connection_class=connection_class,
+        record_class=record_class,
         **connect_kwargs)
 
 

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -594,8 +594,16 @@ async def _create_ssl_connection(protocol_factory, host, port, *,
             raise
 
 
-async def _connect_addr(*, addr, loop, timeout, params, config,
-                        connection_class):
+async def _connect_addr(
+    *,
+    addr,
+    loop,
+    timeout,
+    params,
+    config,
+    connection_class,
+    record_class
+):
     assert loop is not None
 
     if timeout <= 0:
@@ -613,7 +621,7 @@ async def _connect_addr(*, addr, loop, timeout, params, config,
         params = params._replace(password=password)
 
     proto_factory = lambda: protocol.Protocol(
-        addr, connected, params, loop)
+        addr, connected, params, record_class, loop)
 
     if isinstance(addr, str):
         # UNIX socket
@@ -649,7 +657,7 @@ async def _connect_addr(*, addr, loop, timeout, params, config,
     return con
 
 
-async def _connect(*, loop, timeout, connection_class, **kwargs):
+async def _connect(*, loop, timeout, connection_class, record_class, **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
 
@@ -661,9 +669,14 @@ async def _connect(*, loop, timeout, connection_class, **kwargs):
         before = time.monotonic()
         try:
             con = await _connect_addr(
-                addr=addr, loop=loop, timeout=timeout,
-                params=params, config=config,
-                connection_class=connection_class)
+                addr=addr,
+                loop=loop,
+                timeout=timeout,
+                params=params,
+                config=config,
+                connection_class=connection_class,
+                record_class=record_class,
+            )
         except (OSError, asyncio.TimeoutError, ConnectionError) as ex:
             last_error = ex
         else:

--- a/asyncpg/prepared_stmt.py
+++ b/asyncpg/prepared_stmt.py
@@ -103,9 +103,15 @@ class PreparedStatement(connresource.ConnectionResource):
 
         :return: A :class:`~cursor.CursorFactory` object.
         """
-        return cursor.CursorFactory(self._connection, self._query,
-                                    self._state, args, prefetch,
-                                    timeout)
+        return cursor.CursorFactory(
+            self._connection,
+            self._query,
+            self._state,
+            args,
+            prefetch,
+            timeout,
+            self._state.record_class,
+        )
 
     @connresource.guarded
     async def explain(self, *args, analyze=False):

--- a/asyncpg/protocol/codecs/base.pyx
+++ b/asyncpg/protocol/codecs/base.pyx
@@ -7,6 +7,7 @@
 
 from collections.abc import Mapping as MappingABC
 
+import asyncpg
 from asyncpg import exceptions
 
 
@@ -232,7 +233,7 @@ cdef class Codec:
                 schema=self.schema,
                 data_type=self.name,
             )
-        result = record.ApgRecord_New(self.record_desc, elem_count)
+        result = record.ApgRecord_New(asyncpg.Record, self.record_desc, elem_count)
         for i in range(elem_count):
             elem_typ = self.element_type_oids[i]
             received_elem_typ = <uint32_t>hton.unpack_int32(frb_read(buf, 4))

--- a/asyncpg/protocol/prepared_stmt.pxd
+++ b/asyncpg/protocol/prepared_stmt.pxd
@@ -11,6 +11,8 @@ cdef class PreparedStatementState:
         readonly str query
         readonly bint closed
         readonly int refs
+        readonly type record_class
+
 
         list         row_desc
         list         parameters_desc

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -11,7 +11,13 @@ from asyncpg import exceptions
 @cython.final
 cdef class PreparedStatementState:
 
-    def __cinit__(self, str name, str query, BaseProtocol protocol):
+    def __cinit__(
+        self,
+        str name,
+        str query,
+        BaseProtocol protocol,
+        type record_class
+    ):
         self.name = name
         self.query = query
         self.settings = protocol.settings
@@ -21,6 +27,7 @@ cdef class PreparedStatementState:
         self.cols_desc = None
         self.closed = False
         self.refs = 0
+        self.record_class = record_class
 
     def _get_parameters(self):
         cdef Codec codec
@@ -264,7 +271,7 @@ cdef class PreparedStatementState:
                 'different from what was described ({})'.format(
                     fnum, self.cols_num))
 
-        dec_row = record.ApgRecord_New(self.cols_desc, fnum)
+        dec_row = record.ApgRecord_New(self.record_class, self.cols_desc, fnum)
         for i in range(fnum):
             flen = hton.unpack_int32(frb_read(&rbuf, 4))
 

--- a/asyncpg/protocol/protocol.pxd
+++ b/asyncpg/protocol/protocol.pxd
@@ -42,6 +42,7 @@ cdef class BaseProtocol(CoreProtocol):
         object timeout_callback
         object completed_callback
         object conref
+        type record_class
         bint is_reading
 
         str last_query

--- a/asyncpg/protocol/record/__init__.pxd
+++ b/asyncpg/protocol/record/__init__.pxd
@@ -13,7 +13,7 @@ cdef extern from "record/recordobj.h":
 	cpython.PyTypeObject *ApgRecord_InitTypes() except NULL
 
 	int ApgRecord_CheckExact(object)
-	object ApgRecord_New(object, int)
+	object ApgRecord_New(type, object, int)
 	void ApgRecord_SET_ITEM(object, int, object)
 
 	object ApgRecordDesc_New(object, object)

--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -15,9 +15,14 @@ static PyObject * record_new_items_iter(PyObject *);
 static ApgRecordObject *free_list[ApgRecord_MAXSAVESIZE];
 static int numfree[ApgRecord_MAXSAVESIZE];
 
+static size_t MAX_RECORD_SIZE = (
+    ((size_t)PY_SSIZE_T_MAX - sizeof(ApgRecordObject) - sizeof(PyObject *))
+    / sizeof(PyObject *)
+);
+
 
 PyObject *
-ApgRecord_New(PyObject *desc, Py_ssize_t size)
+ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
 {
     ApgRecordObject *o;
     Py_ssize_t i;
@@ -27,19 +32,36 @@ ApgRecord_New(PyObject *desc, Py_ssize_t size)
         return NULL;
     }
 
-    if (size < ApgRecord_MAXSAVESIZE && (o = free_list[size]) != NULL) {
-        free_list[size] = (ApgRecordObject *) o->ob_item[0];
-        numfree[size]--;
-        _Py_NewReference((PyObject *)o);
-    }
-    else {
-        /* Check for overflow */
-        if ((size_t)size > ((size_t)PY_SSIZE_T_MAX - sizeof(ApgRecordObject) -
-                    sizeof(PyObject *)) / sizeof(PyObject *)) {
+    if (type == &ApgRecord_Type) {
+        if (size < ApgRecord_MAXSAVESIZE && (o = free_list[size]) != NULL) {
+            free_list[size] = (ApgRecordObject *) o->ob_item[0];
+            numfree[size]--;
+            _Py_NewReference((PyObject *)o);
+        }
+        else {
+            /* Check for overflow */
+            if ((size_t)size > MAX_RECORD_SIZE) {
+                return PyErr_NoMemory();
+            }
+            o = PyObject_GC_NewVar(ApgRecordObject, &ApgRecord_Type, size);
+            if (o == NULL) {
+                return NULL;
+            }
+        }
+
+        PyObject_GC_Track(o);
+    } else {
+        assert(PyType_IsSubtype(type, &ApgRecord_Type));
+
+        if ((size_t)size > MAX_RECORD_SIZE) {
             return PyErr_NoMemory();
         }
-        o = PyObject_GC_NewVar(ApgRecordObject, &ApgRecord_Type, size);
-        if (o == NULL) {
+        o = (ApgRecordObject *)type->tp_alloc(type, size);
+        if (!_PyObject_GC_IS_TRACKED(o)) {
+            PyErr_SetString(
+                PyExc_TypeError,
+                "record subclass is not tracked by GC"
+            );
             return NULL;
         }
     }
@@ -51,7 +73,6 @@ ApgRecord_New(PyObject *desc, Py_ssize_t size)
     Py_INCREF(desc);
     o->desc = (ApgRecordDescObject*)desc;
     o->self_hash = -1;
-    PyObject_GC_Track(o);
     return (PyObject *) o;
 }
 

--- a/asyncpg/protocol/record/recordobj.h
+++ b/asyncpg/protocol/record/recordobj.h
@@ -46,7 +46,7 @@ extern PyTypeObject ApgRecordDesc_Type;
 			(((ApgRecordObject *)(op))->ob_item[i])
 
 PyTypeObject *ApgRecord_InitTypes(void);
-PyObject *ApgRecord_New(PyObject *, Py_ssize_t);
+PyObject *ApgRecord_New(PyTypeObject *, PyObject *, Py_ssize_t);
 PyObject *ApgRecordDesc_New(PyObject *, PyObject *);
 
 #endif

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -22,6 +22,14 @@ R_AC = collections.OrderedDict([('a', 0), ('c', 1)])
 R_ABC = collections.OrderedDict([('a', 0), ('b', 1), ('c', 2)])
 
 
+class CustomRecord(asyncpg.Record):
+    pass
+
+
+class AnotherCustomRecord(asyncpg.Record):
+    pass
+
+
 class TestRecord(tb.ConnectedTestCase):
 
     @contextlib.contextmanager
@@ -339,3 +347,169 @@ class TestRecord(tb.ConnectedTestCase):
         with self.assertRaisesRegex(
                 TypeError, "cannot create 'asyncpg.Record' instances"):
             asyncpg.Record()
+
+    @tb.with_connection_options(record_class=CustomRecord)
+    async def test_record_subclass_01(self):
+        r = await self.con.fetchrow("SELECT 1 as a, '2' as b")
+        self.assertIsInstance(r, CustomRecord)
+
+        r = await self.con.fetch("SELECT 1 as a, '2' as b")
+        self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = await self.con.cursor("SELECT 1 as a, '2' as b")
+            r = await cur.fetchrow()
+            self.assertIsInstance(r, CustomRecord)
+
+            cur = await self.con.cursor("SELECT 1 as a, '2' as b")
+            r = await cur.fetch(1)
+            self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = self.con.cursor("SELECT 1 as a, '2' as b")
+            async for r in cur:
+                self.assertIsInstance(r, CustomRecord)
+
+        ps = await self.con.prepare("SELECT 1 as a, '2' as b")
+        r = await ps.fetchrow()
+        self.assertIsInstance(r, CustomRecord)
+
+    async def test_record_subclass_02(self):
+        r = await self.con.fetchrow(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        self.assertIsInstance(r, CustomRecord)
+
+        r = await self.con.fetch(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            r = await cur.fetchrow()
+            self.assertIsInstance(r, CustomRecord)
+
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            r = await cur.fetch(1)
+            self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            async for r in cur:
+                self.assertIsInstance(r, CustomRecord)
+
+        ps = await self.con.prepare(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        r = await ps.fetchrow()
+        self.assertIsInstance(r, CustomRecord)
+
+        r = await ps.fetch()
+        self.assertIsInstance(r[0], CustomRecord)
+
+    @tb.with_connection_options(record_class=AnotherCustomRecord)
+    async def test_record_subclass_03(self):
+        r = await self.con.fetchrow(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        self.assertIsInstance(r, CustomRecord)
+
+        r = await self.con.fetch(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            r = await cur.fetchrow()
+            self.assertIsInstance(r, CustomRecord)
+
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            r = await cur.fetch(1)
+            self.assertIsInstance(r[0], CustomRecord)
+
+        async with self.con.transaction():
+            cur = self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=CustomRecord,
+            )
+            async for r in cur:
+                self.assertIsInstance(r, CustomRecord)
+
+        ps = await self.con.prepare(
+            "SELECT 1 as a, '2' as b",
+            record_class=CustomRecord,
+        )
+        r = await ps.fetchrow()
+        self.assertIsInstance(r, CustomRecord)
+
+        r = await ps.fetch()
+        self.assertIsInstance(r[0], CustomRecord)
+
+    @tb.with_connection_options(record_class=CustomRecord)
+    async def test_record_subclass_04(self):
+        r = await self.con.fetchrow(
+            "SELECT 1 as a, '2' as b",
+            record_class=asyncpg.Record,
+        )
+        self.assertIs(type(r), asyncpg.Record)
+
+        r = await self.con.fetch(
+            "SELECT 1 as a, '2' as b",
+            record_class=asyncpg.Record,
+        )
+        self.assertIs(type(r[0]), asyncpg.Record)
+
+        async with self.con.transaction():
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=asyncpg.Record,
+            )
+            r = await cur.fetchrow()
+            self.assertIs(type(r), asyncpg.Record)
+
+            cur = await self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=asyncpg.Record,
+            )
+            r = await cur.fetch(1)
+            self.assertIs(type(r[0]), asyncpg.Record)
+
+        async with self.con.transaction():
+            cur = self.con.cursor(
+                "SELECT 1 as a, '2' as b",
+                record_class=asyncpg.Record,
+            )
+            async for r in cur:
+                self.assertIs(type(r), asyncpg.Record)
+
+        ps = await self.con.prepare(
+            "SELECT 1 as a, '2' as b",
+            record_class=asyncpg.Record,
+        )
+        r = await ps.fetchrow()
+        self.assertIs(type(r), asyncpg.Record)
+
+        r = await ps.fetch()
+        self.assertIs(type(r[0]), asyncpg.Record)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -138,9 +138,9 @@ class TestConnectionCommandTimeout(tb.ConnectedTestCase):
 
 class SlowPrepareConnection(pg_connection.Connection):
     """Connection class to test timeouts."""
-    async def _get_statement(self, query, timeout):
+    async def _get_statement(self, query, timeout, **kwargs):
         await asyncio.sleep(0.3)
-        return await super()._get_statement(query, timeout)
+        return await super()._get_statement(query, timeout, **kwargs)
 
 
 class TestTimeoutCoversPrepare(tb.ConnectedTestCase):


### PR DESCRIPTION
Add the new `record_class` parameter to the `create_pool()` and
`connect()` functions, as well as to the `cursor()`, `prepare()`,
`fetch()` and `fetchrow()` connection methods.

This not only allows adding custom functionality to the returned
objects, but also assists with typing (see #577 for discussion).

Fixes: #40.