### PR TITLE
Fix compilation under Python 3.9+

### DIFF
--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -8,6 +8,11 @@
 
 #include "recordobj.h"
 
+#ifdef _PyObject_GC_IS_TRACKED
+# define _ApgObject_GC_IS_TRACKED _PyObject_GC_IS_TRACKED
+#else
+# define _ApgObject_GC_IS_TRACKED PyObject_GC_IsTracked
+#endif
 
 static PyObject * record_iter(PyObject *);
 static PyObject * record_new_items_iter(PyObject *);
@@ -57,11 +62,7 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
             return PyErr_NoMemory();
         }
         o = (ApgRecordObject *)type->tp_alloc(type, size);
-#ifdef _PyObject_GC_IS_TRACKED
-        if (!_PyObject_GC_IS_TRACKED(o)) {
-#else
-        if (!PyObject_GC_IsTracked(o)) {
-#endif
+        if (!_ApgObject_GC_IS_TRACKED(o)) {
             PyErr_SetString(
                 PyExc_TypeError,
                 "record subclass is not tracked by GC"

--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -57,7 +57,11 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
             return PyErr_NoMemory();
         }
         o = (ApgRecordObject *)type->tp_alloc(type, size);
+#ifdef _PyObject_GC_IS_TRACKED
         if (!_PyObject_GC_IS_TRACKED(o)) {
+#else
+        if (!PyObject_GC_IsTracked(o)) {
+#endif
             PyErr_SetString(
                 PyExc_TypeError,
                 "record subclass is not tracked by GC"


### PR DESCRIPTION
Python 3.9 moved a bunch of GC-related symbols around, including
`_PyObject_GC_IS_TRACKED` which is used in `recordobj.c`.

Fixes: #609