### PR TITLE
Fix wrong default transaction isolation level

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -228,7 +228,7 @@ class Connection(metaclass=ConnectionMeta):
         """
         return self._protocol.get_settings()
 
-    def transaction(self, *, isolation='read_committed', readonly=False,
+    def transaction(self, *, isolation=None, readonly=False,
                     deferrable=False):
         """Create a :class:`~transaction.Transaction` object.
 
@@ -237,7 +237,9 @@ class Connection(metaclass=ConnectionMeta):
 
         :param isolation: Transaction isolation mode, can be one of:
                           `'serializable'`, `'repeatable_read'`,
-                          `'read_committed'`.
+                          `'read_committed'`. If not specified, the behavior
+                          is up to the server and session, which is usually
+                          ``read_committed``.
 
         :param readonly: Specifies whether or not this transaction is
                          read-only.

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -179,3 +179,68 @@ class TestTransaction(tb.ConnectedTestCase):
 
         self.assertIsNone(self.con._top_xact)
         self.assertFalse(self.con.is_in_transaction())
+
+    async def test_isolation_level(self):
+        await self.con.reset()
+        default_isolation = await self.con.fetchval(
+            'SHOW default_transaction_isolation'
+        )
+        isolation_levels = {
+            None: default_isolation,
+            'read_committed': 'read committed',
+            'repeatable_read': 'repeatable read',
+            'serializable': 'serializable',
+        }
+        set_sql = 'SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL '
+        get_sql = 'SHOW TRANSACTION ISOLATION LEVEL'
+        for tx_level in isolation_levels:
+            for conn_level in isolation_levels:
+                with self.subTest(conn=conn_level, tx=tx_level):
+                    if conn_level:
+                        await self.con.execute(
+                            set_sql + isolation_levels[conn_level]
+                        )
+                    level = await self.con.fetchval(get_sql)
+                    self.assertEqual(level, isolation_levels[conn_level])
+                    async with self.con.transaction(isolation=tx_level):
+                        level = await self.con.fetchval(get_sql)
+                        self.assertEqual(
+                            level,
+                            isolation_levels[tx_level or conn_level],
+                        )
+                    await self.con.reset()
+
+    async def test_nested_isolation_level(self):
+        isolation_levels = {
+            None,
+            'read_committed',
+            'repeatable_read',
+            'serializable',
+        }
+        for inner in isolation_levels:
+            for outer in isolation_levels:
+                with self.subTest(outer=outer, inner=inner):
+                    async with self.con.transaction(isolation=outer):
+                        if outer and inner and outer != inner:
+                            with self.assertRaisesRegex(
+                                asyncpg.InterfaceError,
+                                'current {!r} != outer {!r}'.format(
+                                    inner, outer
+                                )
+                            ):
+                                async with self.con.transaction(
+                                        isolation=inner,
+                                ):
+                                    pass
+                        elif not outer and inner:
+                            with self.assertWarnsRegex(
+                                asyncpg.InterfaceWarning,
+                                'current {!r}, outer unknown'.format(inner),
+                            ):
+                                async with self.con.transaction(
+                                        isolation=inner,
+                                ):
+                                    pass
+                        else:
+                            async with self.con.transaction(isolation=inner):
+                                pass


### PR DESCRIPTION
This fixes the issue when the default_transaction_isolation is not "read committed", `transaction(isolation='read_committed')` won't start a transaction in "read committed" isolation level.

There're 2 ways to configure a different default transaction isolation level:

1. `SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL serializable;`. This SQL changes the `default_transaction_isolation` setting, and updates the default transaction isolation level too.

2. Set `default_transaction_isolation` in `postgresql.conf`. This is the server-wide default, most servers keep the default `read committed` value.

| server default | isolation parameter | before PR | after PR |
|---|---|---|---|
| read committed | not set | read committed | read committed |
| read committed | read committed | read committed | read committed |
| read committed | repeatable read | repeatable read | repeatable read |
| read committed | serializable | serializable | serializable |
| serializable | not set | serializable | serializable |
| serializable | read committed | serializable :x: | read committed |
| serializable | repeatable read | repeatable read | repeatable read |
| serializable | serializable | serializable | serializable |

As this PR allows true "unset" transaction isolation level, it is impossible to determine if a nested transaction is started with a different isolation level without extra queries, when isolation is "unset" on the outer transaction.  ~Therefore, this PR will raise a warning if the nested transaction specified an isolation level in this case.~ Update: we are issuing the extra query now.

| outer transaction | nested transaction | behavior |
|---|---|---|
| set | consistent | ✅  |
| set | inconsistent | :x: `InterfaceError` |
| set | unset | ✅  |
| unset | consistent | ✅  with extra query |
| unset | inconsistent | :x: `InterfaceError` with extra query |
| unset | unset | ✅  |