### PR TITLE
Fix AttributeError exception

### DIFF
--- a/asyncpg/protocol/settings.pyx
+++ b/asyncpg/protocol/settings.pyx
@@ -107,7 +107,7 @@ cdef class ConnectionSettings(pgproto.CodecContext):
             except KeyError:
                 raise AttributeError(name) from None
 
-        return object.__getattr__(self, name)
+        return object.__getattribute__(self, name)
 
     def __repr__(self):
         return '<ConnectionSettings {!r}>'.format(self._settings)


### PR DESCRIPTION
* **asyncpg version**: 0.20.1
* **PostgreSQL version**: BDR 11.X
* **Do you use a PostgreSQL SaaS?  If so, which?  Can you reproduce
  the issue with a local PostgreSQL install?**: No SaaS, local BDR
* **Python version**: 3.5.7
* **Platform**: RH Linux
* **Do you use pgbouncer?**: Yes
* **Did you install asyncpg with pip?**: Yes - but custom built
* **If you built asyncpg locally, which version of Cython did you use?**: 0.29.14
* **Can the issue be reproduced under both asyncio and
  [uvloop](https://github.com/magicstack/uvloop)?**: Unknown

<!-- Enter your issue details below this comment. -->

Executing the following code results in `AttributeError` exception - '`object`' has no attribute '`__getattr__`'

```
conn = await asyncpg.connect(dsn=...)
settings = conn.get_settings()
print(settings._settings)
```

I believe the function should be calling `__getattribute__` instead - as in:
```
    def __getattr__(self, name):
        if not name.startswith('_'):
            try:
                return self._settings[name]
            except KeyError:
                raise AttributeError(name) from None

        return object.__getattribute__(self, name)
```