### PR TITLE
Avoid unnecessary pg_listening_channels queries on connection release

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1501,16 +1501,7 @@ class Connection(metaclass=ConnectionMeta):
         if caps.sql_close_all:
             _reset_query.append('CLOSE ALL;')
         if caps.notifications and caps.plpgsql:
-            _reset_query.append('''
-                DO $$
-                BEGIN
-                    PERFORM * FROM pg_listening_channels() LIMIT 1;
-                    IF FOUND THEN
-                        UNLISTEN *;
-                    END IF;
-                END;
-                $$;
-            ''')
+            _reset_query.append('UNLISTEN *;')
         if caps.sql_reset:
             _reset_query.append('RESET ALL;')
 


### PR DESCRIPTION
There's no need to unlisten on all channels if there are no active listeners on the connection. Querying `pg_listening_channels` could be quite time consuming even when no listeners are added. For example, 20% of all time spent on DB operations goes to `pg_listening_channels` on our project. 