### PR TITLE
fix link in connect docstring

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1920,7 +1920,7 @@ async def connect(dsn=None, *,
         https://www.postgresql.org/docs/current/static/libpq-envars.html
     .. _libpq connection URI format:
         https://www.postgresql.org/docs/current/static/\
-libpq-connect.html#LIBPQ-CONNSTRING
+    libpq-connect.html#LIBPQ-CONNSTRING
     """
     if not issubclass(connection_class, Connection):
         raise TypeError(

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1919,8 +1919,8 @@ async def connect(dsn=None, *,
     .. _postgres envvars:
         https://www.postgresql.org/docs/current/static/libpq-envars.html
     .. _libpq connection URI format:
-        https://www.postgresql.org/docs/current/static/\
-    libpq-connect.html#LIBPQ-CONNSTRING
+        https://www.postgresql.org/docs/current/static/
+        libpq-connect.html#LIBPQ-CONNSTRING
     """
     if not issubclass(connection_class, Connection):
         raise TypeError(

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1920,7 +1920,7 @@ async def connect(dsn=None, *,
         https://www.postgresql.org/docs/current/static/libpq-envars.html
     .. _libpq connection URI format:
         https://www.postgresql.org/docs/current/static/\
-        libpq-connect.html#LIBPQ-CONNSTRING
+libpq-connect.html#LIBPQ-CONNSTRING
     """
     if not issubclass(connection_class, Connection):
         raise TypeError(


### PR DESCRIPTION
Until now the url had a space in it which means the link was to 

    https://www.postgresql.org/docs/current/%20libpq-connect.html#LIBPQ-CONNSTRING

which shows a 404.

see https://magicstack.github.io/asyncpg/current/api/index.html

This should fix it.