### PR TITLE
Prefer SSL connections by default

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -380,6 +380,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 passfile=passfile)
 
     addrs = []
+    have_tcp_addrs = False
     for h, p in zip(host, port):
         if h.startswith('/'):
             # UNIX socket name
@@ -389,6 +390,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
         else:
             # TCP host/port
             addrs.append((h, p))
+            have_tcp_addrs = True
 
     if not addrs:
         raise ValueError(
@@ -396,6 +398,9 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
 
     if ssl is None:
         ssl = os.getenv('PGSSLMODE')
+
+    if ssl is None and have_tcp_addrs:
+        ssl = 'prefer'
 
     # ssl_is_advisory is only allowed to come from the sslmode parameter.
     ssl_is_advisory = None
@@ -435,14 +440,8 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
             if sslmode <= SSLMODES['require']:
                 ssl.verify_mode = ssl_module.CERT_NONE
             ssl_is_advisory = sslmode <= SSLMODES['prefer']
-
-    if ssl:
-        for addr in addrs:
-            if isinstance(addr, str):
-                # UNIX socket
-                raise exceptions.InterfaceError(
-                    '`ssl` parameter can only be enabled for TCP addresses, '
-                    'got a UNIX socket path: {!r}'.format(addr))
+    elif ssl is True:
+        ssl = ssl_module.create_default_context()
 
     if server_settings is not None and (
             not isinstance(server_settings, dict) or
@@ -542,9 +541,6 @@ class TLSUpgradeProto(asyncio.Protocol):
 async def _create_ssl_connection(protocol_factory, host, port, *,
                                  loop, ssl_context, ssl_is_advisory=False):
 
-    if ssl_context is True:
-        ssl_context = ssl_module.create_default_context()
-
     tr, pr = await loop.create_connection(
         lambda: TLSUpgradeProto(loop, host, port,
                                 ssl_context, ssl_is_advisory),
@@ -625,7 +621,6 @@ async def _connect_addr(
 
     if isinstance(addr, str):
         # UNIX socket
-        assert not params.ssl
         connector = loop.create_unix_connection(proto_factory, addr)
     elif params.ssl:
         connector = _create_ssl_connection(

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1869,7 +1869,28 @@ async def connect(dsn=None, *,
         Pass ``True`` or an `ssl.SSLContext <SSLContext_>`_ instance to
         require an SSL connection.  If ``True``, a default SSL context
         returned by `ssl.create_default_context() <create_default_context_>`_
-        will be used.
+        will be used.  The value can also be one of the following strings:
+
+        - ``'disable'`` - SSL is disabled (equivalent to ``False``)
+        - ``'prefer'`` - try SSL first, fallback to non-SSL connection
+          if SSL connection fails
+        - ``'allow'`` - currently equivalent to ``'prefer'``
+        - ``'require'`` - only try an SSL connection.  Certificate
+          verifiction errors are ignored
+        - ``'verify-ca'`` - only try an SSL connection, and verify
+          that the server certificate is issued by a trusted certificate
+          authority (CA)
+        - ``'verify-full'`` - only try an SSL connection, verify
+          that the server certificate is issued by a trusted CA and
+          that the requested server host name matches that in the
+          certificate.
+
+        The default is ``'prefer'``: try an SSL connection and fallback to
+        non-SSL connection if that fails.
+
+        .. note::
+
+           *ssl* is ignored for Unix domain socket communication.
 
     :param dict server_settings:
         An optional dict of server runtime parameters.  Refer to
@@ -1925,6 +1946,9 @@ async def connect(dsn=None, *,
 
     .. versionchanged:: 0.22.0
        Added the *record_class* parameter.
+
+    .. versionchanged:: 0.22.0
+       The *ssl* argument now defaults to ``'prefer'``.
 
     .. _SSLContext: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
     .. _create_default_context:


### PR DESCRIPTION
Switch the default SSL mode from 'disabled' to 'prefer'.  This matches libpq's behavior and is a sensible thing to do.

Fixes: #654