### PR TITLE
asyncpg v0.22.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,6 @@ jobs:
         release_name: v${{ steps.relver.outputs.version }}
         target: ${{ github.event.pull_request.base.ref }}
         body: ${{ github.event.pull_request.body }}
-        draft: true
 
     - run: |
         ls -al dist/
@@ -304,6 +303,6 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__
-        # password: ${{ secrets.PYPI_TOKEN }}
-        password: ${{ secrets.TEST_PYPI_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_TOKEN }}
+        # password: ${{ secrets.TEST_PYPI_TOKEN }}
+        # repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        arch: [x86_64, aarch64]
+        arch: [x86_64]
         exclude:
           # Python 3.5 is unable to properly
           # find the recent VS tooling

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.22.0.dev0'
+__version__ = '0.22.0'


### PR DESCRIPTION
A new asyncpg release is here.

Notable additions include Python 3.9 support, support for recently added
PostgreSQL types like `jsonpath`, and last but not least, vastly
improved `executemany()` performance.  Importantly, `executemany()` is
also now _atomic_, which means that either all iterations succeed, or
none at all, whereas previously partial results would have remained in
place, unless `executemany()` was called in a transaction.

There is also the usual assortment of improvements and bugfixes, see the
details below.

This is the last release of asyncpg that supports Python 3.5, which has
reached EOL last September.

Improvements
------------

* Vastly speedup executemany by batching protocol messages (#295)
  (by @fantix in 690048db for #295)

* Allow using custom `Record` class
  (by @elprans in db4f1a6c for #577)

* Add Python 3.9 support (#610)
  (by @elprans in c05d7260 for #610)

* Prefer SSL connections by default (#660)
  (by @elprans in 16183aa0 for #660)

* Add codecs for a bunch of new builtin types (#665)
  (by @elprans in b53f0384 for #665)

* Expose Pool as `asyncpg.Pool` (#669)
  (by @rugleb in 0e0eb8d3 for #669)

* Avoid unnecessary overhead during connection reset (#648)
  (by @kitogo in ff5da5f9 for #648)

Fixes
-----

* Add a workaround for bpo-37658
  (by @elprans in 2bac166c for #21894)

* Fix wrong default transaction isolation level (#622)
  (by @fantix in 4a627d55 for #622)

* Fix `set_type_codec()` to accept standard SQL type names (#619)
  (by @elprans in 68b40cbf for #619)

* Ignore custom data codec for internal introspection (#618)
  (by @fantix in e064f59e for #618)

* Fix null/NULL quoting in array text encoder (#627)
  (by @fantix in 92aa8062 for #627)

* Fix link in connect docstring (#653)
  (by @samuelcolvin in 8b313bde for #653)

* Make asyncpg work with pyinstaller (#651)
  (by @Atem18 in 5ddabb19 for #651)

* Fix possible `AttributeError` exception in `ConnectionSettings` (#632)
  (by @petriborg in 0d231820 for #632)

* Prohibit custom codecs on domains
  (by @elprans in 50f964fc for #457)

* Raise proper error on anonymous composite input (tuple arguments) (#664)
  (by @elprans in 7252dbeb for #664)

* Fix incorrect application of custom codecs in some cases (#662)
  (by @elprans in 50f65fbb for #662)