### PR TITLE
docs: fix simple typo, verifiction -> verification

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1890,7 +1890,7 @@ async def connect(dsn=None, *,
           if SSL connection fails
         - ``'allow'`` - currently equivalent to ``'prefer'``
         - ``'require'`` - only try an SSL connection.  Certificate
-          verifiction errors are ignored
+          verification errors are ignored
         - ``'verify-ca'`` - only try an SSL connection, and verify
           that the server certificate is issued by a trusted certificate
           authority (CA)


### PR DESCRIPTION
There is a small typo in asyncpg/connection.py.

Should read `verification` rather than `verifiction`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md