### PR TITLE
Execute UNLISTEN unconditionally in connection reset query

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1500,17 +1500,8 @@ class Connection(metaclass=ConnectionMeta):
             _reset_query.append('SELECT pg_advisory_unlock_all();')
         if caps.sql_close_all:
             _reset_query.append('CLOSE ALL;')
-        if caps.notifications and caps.plpgsql:
-            _reset_query.append('''
-                DO $$
-                BEGIN
-                    PERFORM * FROM pg_listening_channels() LIMIT 1;
-                    IF FOUND THEN
-                        UNLISTEN *;
-                    END IF;
-                END;
-                $$;
-            ''')
+        if caps.notifications:
+            _reset_query.append('UNLISTEN *;')
         if caps.sql_reset:
             _reset_query.append('RESET ALL;')
 


### PR DESCRIPTION
Currently, `UNLISTEN` in connection release is guarded by an
expensive PL/pgSQL block, because historically PostgreSQL
did not allow `UNLISTEN` on a hot standby node.  This has since
changed, and `UNLISTEN` is allowed in PostgreSQL 9.4.21+, 9.5.16+,
9.6.12+, 10.7+, 11.2+, and versions 12 and newer.  If this change
breaks your setup, upgrade your server.

The removal of the PL/pgSQL guard reduces the `acquire`/`release` overhead
by over 50%.

Upstream discussion: https://postgr.es/m/CADT4RqCf2gA_TJtPAjnGzkC3ZiexfBZiLmA-mV66e4UyuVv8bA@mail.gmail.com

Fixes: #648