### PR TITLE
Fix docs/Makefile and docs/_static/theme_overrides.css missing from PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include docs *.py *.rst
+recursive-include docs *.py *.rst Makefile *.css
 recursive-include examples *.py
 recursive-include tests *.py *.pem
 recursive-include asyncpg *.pyx *.pxd *.pxi *.py *.c *.h


### PR DESCRIPTION
Add patterns matching them to `MANIFEST.in`.