### PR TITLE
Feed memoryview to writelines()

### DIFF
--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -952,7 +952,7 @@ cdef class CoreProtocol:
                     else:
                         # otherwise, append SYNC and send the buffers
                         packet.write_bytes(SYNC_MESSAGE)
-                        buffers.append(packet)
+                        buffers.append(memoryview(packet))
                         self._writelines(buffers)
                     return False
 
@@ -976,7 +976,7 @@ cdef class CoreProtocol:
                 )
 
             # collected one buffer
-            buffers.append(packet)
+            buffers.append(memoryview(packet))
 
         # write to the wire, and signal the caller for more to send
         self._writelines(buffers)


### PR DESCRIPTION
This fixes an issue in 0.22.0 where we passed WriteBuffer to writelines by mistake, which leads to an error under SSL and uvloop - the implementation that calls len() on each line of writelines().

Fixes: #700