### PR TITLE
Updated int the doc PostgreSQL versions supported

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.
 
 **asyncpg** requires Python 3.5 or later and is supported for PostgreSQL
-versions 9.2 to 12.
+versions 9.5 to 13.
 
 Contents
 --------


### PR DESCRIPTION
The README.md says that PostgreSQL versions supported are 9.5 to 13,
copied to the doc.