### PR TITLE
Fix asyncpg with Py_DEBUG mode

### DIFF
--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -31,6 +31,7 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
 {
     ApgRecordObject *o;
     Py_ssize_t i;
+   int need_gc_track = 0;
 
     if (size < 0 || desc == NULL || !ApgRecordDesc_CheckExact(desc)) {
         PyErr_BadInternalCall();
@@ -54,7 +55,7 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
             }
         }
 
-        PyObject_GC_Track(o);
+        need_gc_track = 1;
     } else {
         assert(PyType_IsSubtype(type, &ApgRecord_Type));
 
@@ -78,6 +79,9 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
     Py_INCREF(desc);
     o->desc = (ApgRecordDescObject*)desc;
     o->self_hash = -1;
+    if (need_gc_track) {
+        PyObject_GC_Track(o);
+    }
     return (PyObject *) o;
 }
 

--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -31,7 +31,7 @@ ApgRecord_New(PyTypeObject *type, PyObject *desc, Py_ssize_t size)
 {
     ApgRecordObject *o;
     Py_ssize_t i;
-   int need_gc_track = 0;
+    int need_gc_track = 0;
 
     if (size < 0 || desc == NULL || !ApgRecordDesc_CheckExact(desc)) {
         PyErr_BadInternalCall();


### PR DESCRIPTION
If Py_DEBUG enabled, then newly allocated memory is filled with the byte 0xCD (CLEANBYTE) https://docs.python.org/3/c-api/memory.html#c.PyMem_SetupDebugHooks

This breaks checks for `pointer == NULL` and results in crash.

From documentation PyObject_GC_Track https://docs.python.org/3/c-api/gcsupport.html#c.PyObject_GC_Track
> This should be called once all the fields followed by the tp_traverse handler become valid, usually near the end of the constructor.