### PR TITLE
Upgrade pip and setuptools in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
     - name: Install Python Deps
       if: steps.release.outputs.version == 0
       run: |
+        pip install -U pip setuptools
         pip install -e .[test]
 
     - name: Test
@@ -117,6 +118,7 @@ jobs:
     - name: Install Python Deps
       if: steps.release.outputs.version == 0
       run: |
+        pip install -U pip setuptools
         pip install -e .[test]
 
     - name: Test


### PR DESCRIPTION
Python 3.5 on GitHub Action ran into some certificate issue that newer version of pip doesn't have, so upgrading to the latest by default.