### PR TITLE
asyncpg v0.23.0

### DIFF
--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.23.0.dev0'
+__version__ = '0.23.0'


### PR DESCRIPTION
Fixes
-----

* Avoid TypeError in `Transaction.__repr__` (#703)
  (by @BeatButton in d6eea8ed for #703)

* Feed memoryview to `writelines()` (#715)
  (by @fantix in 359a34c4 for #715)

* Add sslmode=allow support and fix =prefer retry (#720)
  (by @fantix in 075114c1 for #720)

* Loosen message test in `test_invalid_input` (#751)
  (by @musicinmybrain in bc4127f4 for #751)

* Support readonly and deferrable for non-serializable transactions (#747)
  (by @pauldraper in 5cf4089a for #747)

* Fix asyncpg with `Py_DEBUG` mode (#719)
  (by @shadchin in a113d908 for #719)

* Fix docs/Makefile and docs/_static/theme_overrides.css missing from PyPI package (#708)
  (by @musicinmybrain in c3060680 for #708)