### PR TITLE
Fix unique ID generation

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -6,6 +6,8 @@
 
 
 import asyncio
+import uuid
+
 import asyncpg
 import collections
 import collections.abc
@@ -1344,9 +1346,10 @@ class Connection(metaclass=ConnectionMeta):
             raise exceptions.InterfaceError('connection is closed')
 
     def _get_unique_id(self, prefix):
-        global _uid
-        _uid += 1
-        return '__asyncpg_{}_{:x}__'.format(prefix, _uid)
+        return '__asyncpg_{prefix}_{uuid}__'.format(
+            prefix=prefix,
+            uuid=uuid.uuid4(),
+        )
 
     def _mark_stmts_as_closed(self):
         for stmt in self._stmt_cache.iter_statements():
@@ -2258,6 +2261,3 @@ def _check_record_class(record_class):
             'record_class is expected to be a subclass of '
             'asyncpg.Record, got {!r}'.format(record_class)
         )
-
-
-_uid = 0

--- a/tests/test__sourcecode.py
+++ b/tests/test__sourcecode.py
@@ -17,10 +17,10 @@ def find_root():
 class TestFlake8(unittest.TestCase):
 
     def test_flake8(self):
-        # try:
-        #     import flake8  # NoQA
-        # except ImportError:
-        raise unittest.SkipTest('flake8 module is missing')
+        try:
+            import flake8  # NoQA
+        except ImportError:
+            raise unittest.SkipTest('flake8 module is missing')
 
         root_path = find_root()
         config_path = os.path.join(root_path, '.flake8')

--- a/tests/test__sourcecode.py
+++ b/tests/test__sourcecode.py
@@ -17,10 +17,10 @@ def find_root():
 class TestFlake8(unittest.TestCase):
 
     def test_flake8(self):
-        try:
-            import flake8  # NoQA
-        except ImportError:
-            raise unittest.SkipTest('flake8 module is missing')
+        # try:
+        #     import flake8  # NoQA
+        # except ImportError:
+        raise unittest.SkipTest('flake8 module is missing')
 
         root_path = find_root()
         config_path = os.path.join(root_path, '.flake8')


### PR DESCRIPTION
If asyncpg is used in different processes/threads it will generate prepared statements with the same ID. It causes conflicts and errors (like [this one](https://github.com/sqlalchemy/sqlalchemy/issues/6467), for example). One of the options is using PID in the `_get_unique_id` function, but I think it will be overkill. 

