### PR TITLE
Fix parsing of IPv6 addresses in the connection URI

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1796,7 +1796,13 @@ async def connect(dsn=None, *,
         .. note::
 
            The URI must be *valid*, which means that all components must
-           be properly quoted with :py:func:`urllib.parse.quote`.
+           be properly quoted with :py:func:`urllib.parse.quote`, and
+           any literal IPv6 addresses must be enclosed in square brackets.
+           For example:
+
+           .. code-block:: text
+
+              postgres://dbuser@[fe80::1ff:fe23:4567:890a%25eth0]/dbname
 
     :param host:
         Database host address as one of the following:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -512,6 +512,34 @@ class TestConnectParams(tb.TestCase):
         },
 
         {
+            'name': 'dsn_ipv6_multi_host',
+            'dsn': 'postgresql://user@[2001:db8::1234%25eth0],[::1]/db',
+            'result': ([('2001:db8::1234%eth0', 5432), ('::1', 5432)], {
+                'database': 'db',
+                'user': 'user',
+            })
+        },
+
+        {
+            'name': 'dsn_ipv6_multi_host_port',
+            'dsn': 'postgresql://user@[2001:db8::1234]:1111,[::1]:2222/db',
+            'result': ([('2001:db8::1234', 1111), ('::1', 2222)], {
+                'database': 'db',
+                'user': 'user',
+            })
+        },
+
+        {
+            'name': 'dsn_ipv6_multi_host_query_part',
+            'dsn': 'postgresql:///db?user=user&host=[2001:db8::1234],[::1]',
+            'result': ([('2001:db8::1234', 5432), ('::1', 5432)], {
+                'database': 'db',
+                'user': 'user',
+            })
+        },
+
+
+        {
             'name': 'dsn_combines_env_multi_host',
             'env': {
                 'PGHOST': 'host1:1111,host2:2222',


### PR DESCRIPTION
Plain IPv6 addresses specified in square brackets in the connection URI
are now parsed correctly.

Fixes: #838.