### PR TITLE
Make it possible to specify a statement name in Connection.prepare()

### DIFF
--- a/asyncpg/prepared_stmt.py
+++ b/asyncpg/prepared_stmt.py
@@ -25,6 +25,14 @@ class PreparedStatement(connresource.ConnectionResource):
         self._last_status = None
 
     @connresource.guarded
+    def get_name(self) -> str:
+        """Return the name of this prepared statement.
+
+        .. versionadded:: 0.25.0
+        """
+        return self._state.name
+
+    @connresource.guarded
     def get_query(self) -> str:
         """Return the text of the query for this prepared statement.
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -600,3 +600,14 @@ class TestPrepare(tb.ConnectedTestCase):
         # prepare with disabled cache
         await self.con.prepare('select 1')
         self.assertEqual(len(cache), 0)
+
+    async def test_prepare_explicitly_named(self):
+        ps = await self.con.prepare('select 1', name='foobar')
+        self.assertEqual(ps.get_name(), 'foobar')
+        self.assertEqual(await self.con.fetchval('EXECUTE foobar'), 1)
+
+        with self.assertRaisesRegex(
+            exceptions.DuplicatePreparedStatementError,
+            'prepared statement "foobar" already exists',
+        ):
+            await self.con.prepare('select 1', name='foobar')


### PR DESCRIPTION
This adds the new `name` keyword argument to `Connection.prepare()` and
`PreparedStatement.get_name()` method returning the name of a statement.

Some users of asyncpg might find it useful to be able to control how
prepared statements are named, especially when a custom prepared
statement caching scheme is in use.  Specifically, This should help with
pgbouncer support in SQLAlchemy asyncpg dialect.

Fixes: #837.