### PR TITLE
Improve diagnostics of invalid executemany() input

### DIFF
--- a/asyncpg/protocol/prepared_stmt.pxd
+++ b/asyncpg/protocol/prepared_stmt.pxd
@@ -29,7 +29,7 @@ cdef class PreparedStatementState:
         bint         have_text_cols
         tuple        rows_codecs
 
-    cdef _encode_bind_msg(self, args)
+    cdef _encode_bind_msg(self, args, int seqno = ?)
     cpdef _init_codecs(self)
     cdef _ensure_rows_decoder(self)
     cdef _ensure_args_encoder(self)

--- a/asyncpg/protocol/prepared_stmt.pyx
+++ b/asyncpg/protocol/prepared_stmt.pyx
@@ -101,11 +101,24 @@ cdef class PreparedStatementState:
     def mark_closed(self):
         self.closed = True
 
-    cdef _encode_bind_msg(self, args):
+    cdef _encode_bind_msg(self, args, int seqno = -1):
         cdef:
             int idx
             WriteBuffer writer
             Codec codec
+
+        if not cpython.PySequence_Check(args):
+            if seqno >= 0:
+                raise exceptions.DataError(
+                    f'invalid input in executemany() argument sequence '
+                    f'element #{seqno}: expected a sequence, got '
+                    f'{type(args).__name__}'
+                )
+            else:
+                # Non executemany() callers do not pass user input directly,
+                # so bad input is a bug.
+                raise exceptions.InternalClientError(
+                    f'Bind: expected a sequence, got {type(args).__name__}')
 
         if len(args) > 32767:
             raise exceptions.InterfaceError(
@@ -159,19 +172,32 @@ cdef class PreparedStatementState:
                 except exceptions.InterfaceError as e:
                     # This is already a descriptive error, but annotate
                     # with argument name for clarity.
+                    pos = f'${idx + 1}'
+                    if seqno >= 0:
+                        pos = (
+                            f'{pos} in element #{seqno} of'
+                            f' executemany() sequence'
+                        )
                     raise e.with_msg(
-                        f'query argument ${idx + 1}: {e.args[0]}') from None
+                        f'query argument {pos}: {e.args[0]}'
+                    ) from None
                 except Exception as e:
                     # Everything else is assumed to be an encoding error
                     # due to invalid input.
+                    pos = f'${idx + 1}'
+                    if seqno >= 0:
+                        pos = (
+                            f'{pos} in element #{seqno} of'
+                            f' executemany() sequence'
+                        )
                     value_repr = repr(arg)
                     if len(value_repr) > 40:
                         value_repr = value_repr[:40] + '...'
 
                     raise exceptions.DataError(
-                        'invalid input for query argument'
-                        ' ${n}: {v} ({msg})'.format(
-                            n=idx + 1, v=value_repr, msg=e)) from e
+                        f'invalid input for query argument'
+                        f' {pos}: {value_repr} ({e})'
+                    ) from e
 
         if self.have_text_cols:
             writer.write_int16(self.cols_num)

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -217,7 +217,7 @@ cdef class BaseProtocol(CoreProtocol):
         # Make sure the argument sequence is encoded lazily with
         # this generator expression to keep the memory pressure under
         # control.
-        data_gen = (state._encode_bind_msg(b) for b in args)
+        data_gen = (state._encode_bind_msg(b, i) for i, b in enumerate(args))
         arg_bufs = iter(data_gen)
 
         waiter = self._new_waiter(timeout)


### PR DESCRIPTION
This adds a check that elements of sequence passed to `executemany()`
are proper sequences themselves and notes the offending sequence element
number in the exception message.  For example:

    await self.con.executemany(
        "INSERT INTO exmany (b) VALUES($1)"
        [(0,), ("bad",)],
    )

    DataError: invalid input for query argument $1 in element #1 of
               executemany() sequence: 'bad' ('str' object cannot be
               interpreted as an integer)

Fixes: #807