### PR TITLE
Don't limit required cython version from above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command import sdist as setuptools_sdist
 from setuptools.command import build_ext as setuptools_build_ext
 
 
-CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24)'
 
 # Minimal dependencies required to test asyncpg.
 TEST_DEPENDENCIES = [


### PR DESCRIPTION
This fixes build with cython 3.0.0a9 (from git) and is required for python 3.11 support.