### PR TITLE
Domain basetypes are introspected (#886)

### DIFF
--- a/asyncpg/introspection.py
+++ b/asyncpg/introspection.py
@@ -109,6 +109,7 @@ AS (
         (tt.elemtype IS NOT NULL AND ti.oid = tt.elemtype)
         OR (tt.attrtypoids IS NOT NULL AND ti.oid = any(tt.attrtypoids))
         OR (tt.range_subtype IS NOT NULL AND ti.oid = tt.range_subtype)
+        OR (tt.basetype IS NOT NULL AND ti.oid = tt.basetype)
 )
 
 SELECT DISTINCT
@@ -232,6 +233,7 @@ AS (
         (tt.elemtype IS NOT NULL AND ti.oid = tt.elemtype)
         OR (tt.attrtypoids IS NOT NULL AND ti.oid = any(tt.attrtypoids))
         OR (tt.range_subtype IS NOT NULL AND ti.oid = tt.range_subtype)
+        OR (tt.basetype IS NOT NULL AND ti.oid = tt.basetype)
 )
 
 SELECT DISTINCT

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -193,8 +193,8 @@ class TestIntrospection(tb.ConnectedTestCase):
 
     @tb.with_connection_options(database='asyncpg_intro_test')
     async def test_introspection_loads_basetypes_of_domains(self):
-        # Test that basetypes of domains are loaded to the client encode/decode
-        # cache
+        # Test that basetypes of domains are loaded to the 
+        # client encode/decode cache
         await self.con.execute('''
             DROP TABLE IF EXISTS test;
             DROP DOMAIN IF EXISTS num_array;

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -206,7 +206,8 @@ class TestIntrospection(tb.ConnectedTestCase):
 
         try:
             # if domain basetypes are not loaded, this insert will fail
-            await self.con.execute('INSERT INTO test (num) VALUES ($1)', ([1, 2],))
+            await self.con.execute(
+                'INSERT INTO test (num) VALUES ($1)', ([1, 2],))
         finally:
             await self.con.execute('''
                 DROP TABLE IF EXISTS test;

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -190,3 +190,25 @@ class TestIntrospection(tb.ConnectedTestCase):
                 DROP DOMAIN intro_2_t;
             ''')
             await slow_intro_conn.close()
+
+    @tb.with_connection_options(database='asyncpg_intro_test')
+    async def test_introspection_loads_basetypes_of_domains(self):
+        # Test that basetypes of domains are loaded to the client encode/decode
+        # cache
+        await self.con.execute('''
+            DROP TABLE IF EXISTS test;
+            DROP DOMAIN IF EXISTS num_array;
+            CREATE DOMAIN num_array numeric[];
+            CREATE TABLE test (
+                num num_array
+            );
+        ''')
+
+        try:
+            # if domain basetypes are not loaded, this insert will fail
+            await self.con.execute('INSERT INTO test (num) VALUES ($1)', ([1, 2],))
+        finally:
+            await self.con.execute('''
+                DROP TABLE IF EXISTS test;
+                DROP DOMAIN IF EXISTS num_array;
+            ''')

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -193,7 +193,7 @@ class TestIntrospection(tb.ConnectedTestCase):
 
     @tb.with_connection_options(database='asyncpg_intro_test')
     async def test_introspection_loads_basetypes_of_domains(self):
-        # Test that basetypes of domains are loaded to the 
+        # Test that basetypes of domains are loaded to the
         # client encode/decode cache
         await self.con.execute('''
             DROP TABLE IF EXISTS test;


### PR DESCRIPTION
Domain encoding/decoding is handled by its basetype. This change forces
those basetypes to be inspected and loaded to the client cache avoiding
the issue where base types weren't encodable/decodable.