### PR TITLE
Drop `[project]` from `pyproject.toml` for forward-compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[project]
-name = "asyncpg"
-requires-python = ">=3.6"
-
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
https://github.com/MagicStack/asyncpg/pull/900#issuecomment-1079653458

As @abravalheri advised, it is better to drop the `[project]` table from `pyproject.toml` to avoid the future releases of setuptools ignoring the configurations listed in `setup.py`.