### PR TITLE
Adopt PEP 621, move metadata into `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
 ]
 
 [project.urls]
-github = "https://github.com/MagicStack/asyncpg"
+homepage = "https://github.com/MagicStack/asyncpg"
+documentation = "https://magicstack.github.io/asyncpg/current/"
+repository = "https://github.com/MagicStack/asyncpg"
+changelog = "https://github.com/MagicStack/asyncpg/releases"
 
 [project.optional-dependencies]
 test = [
@@ -43,7 +46,7 @@ docs = [
 
 [build-system]
 requires = [
-    "setuptools>=60",
+    "setuptools>=61",
     "wheel",
 
     "Cython(>=0.29.24,<0.30.0)"
@@ -51,6 +54,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
+platforms = ["macOS", "POSIX", "Windows"]
 zip-safe = false
 
 [tool.setuptools.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,10 @@ import platform
 import re
 import subprocess
 
+import setuptools
+
 # We use vanilla build_ext, to avoid importing Cython via
 # the setuptools version.
-import setuptools
 from setuptools.command import build_py as setuptools_build_py
 from setuptools.command import sdist as setuptools_sdist
 from setuptools.command import build_ext as setuptools_build_ext
@@ -35,10 +36,6 @@ if platform.uname().system != 'Windows':
 
 
 _ROOT = pathlib.Path(__file__).parent
-
-
-with open(str(_ROOT / 'README.rst')) as f:
-    readme = f.read()
 
 
 with open(str(_ROOT / 'asyncpg' / '_version.py')) as f:


### PR DESCRIPTION
https://github.com/MagicStack/asyncpg/pull/900#issuecomment-1079653458

> Support for declaring [project metadata](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/) or configuring `setuptools` via `pyproject.toml` files is still experimental and might change (or be removed) in future releases.

As @abravalheri advised, we should either drop the `[project]` table (#903) or fully adopt PEP 621 (this PR). However, since the support for `pyproject.toml` of `setuptools` is still experimental and requires a fairly high `setuptools` version, we'd better wait at least until it stabilizes and `asyncpg` officially drops the compatibility with Python 3.6. I will keep tracking on this.

If the maintainers are never willing to adopt PEP 621 even in the foreseeable future, just close this PR.