### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,10 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:
-          # uvloop does not support Python 3.6
-          - loop: uvloop
-            python-version: "3.6"
           # uvloop does not support windows
           - loop: uvloop
             os: windows-latest

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.  You can read more about asyncpg in an introductory
 `blog post <http://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/>`_.
 
-asyncpg requires Python 3.6 or later and is supported for PostgreSQL
+asyncpg requires Python 3.7 or later and is supported for PostgreSQL
 versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -8,10 +8,8 @@
 import asyncio
 import pathlib
 import platform
-import sys
 
 
-PY_37 = sys.version_info >= (3, 7)
 SYSTEM = platform.uname().system
 
 
@@ -34,14 +32,6 @@ if SYSTEM == 'Windows':
 else:
     def get_pg_home_directory() -> pathlib.Path:
         return pathlib.Path.home()
-
-
-if PY_37:
-    def current_asyncio_task(loop):
-        return asyncio.current_task(loop)
-else:
-    def current_asyncio_task(loop):
-        return asyncio.Task.current_task(loop)
 
 
 async def wait_closed(stream):

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -237,10 +237,6 @@ def _parse_hostlist(hostlist, port, *, unquote=False):
 
 
 def _parse_tls_version(tls_version):
-    if not hasattr(ssl_module, 'TLSVersion'):
-        raise ValueError(
-            "TLSVersion is not supported in this version of Python"
-        )
     if tls_version.startswith('SSL'):
         raise ValueError(
             f"Unsupported TLS version: {tls_version}"
@@ -573,11 +569,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                     ssl_min_protocol_version
                 )
             else:
-                try:
-                    ssl.minimum_version = _parse_tls_version('TLSv1.2')
-                except ValueError:
-                    # Python 3.6 does not have ssl.TLSVersion
-                    pass
+                ssl.minimum_version = _parse_tls_version('TLSv1.2')
 
             if ssl_max_protocol_version is None:
                 ssl_max_protocol_version = os.getenv('PGSSLMAXPROTOCOLVERSION')

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -20,7 +20,6 @@ import typing
 import warnings
 import weakref
 
-from . import compat
 from . import connect_utils
 from . import cursor
 from . import exceptions
@@ -1468,7 +1467,7 @@ class Connection(metaclass=ConnectionMeta):
                 waiter.set_exception(ex)
         finally:
             self._cancellations.discard(
-                compat.current_asyncio_task(self._loop))
+                asyncio.current_task(self._loop))
             if not waiter.done():
                 waiter.set_result(None)
 

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -43,10 +43,6 @@ class PoolConnectionProxyMeta(type):
 
         return super().__new__(mcls, name, bases, dct)
 
-    def __init__(cls, name, bases, dct, *, wrap=False):
-        # Needed for Python 3.5 to handle `wrap` class keyword argument.
-        super().__init__(name, bases, dct)
-
     @staticmethod
     def _wrap_connection_method(meth_name):
         def call_con_method(self, *args, **kwargs):

--- a/asyncpg/protocol/scram.pyx
+++ b/asyncpg/protocol/scram.pyx
@@ -9,17 +9,10 @@ import base64
 import hashlib
 import hmac
 import re
+import secrets
 import stringprep
 import unicodedata
 
-
-# try to import the secrets library from Python 3.6+ for the
-# cryptographic token generator for generating nonces as part of SCRAM
-# Otherwise fall back on os.urandom
-try:
-    from secrets import token_bytes as generate_token_bytes
-except ImportError:
-    from os import urandom as generate_token_bytes
 
 @cython.final
 cdef class SCRAMAuthentication:
@@ -198,7 +191,7 @@ cdef class SCRAMAuthentication:
         cdef:
             bytes token
 
-        token = generate_token_bytes(num_bytes)
+        token = secrets.token_bytes(num_bytes)
 
         return base64.b64encode(token)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ PostgreSQL and Python/asyncio.  asyncpg is an efficient, clean implementation
 of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.
 
-**asyncpg** requires Python 3.6 or later and is supported for PostgreSQL
+**asyncpg** requires Python 3.7 or later and is supported for PostgreSQL
 versions 9.5 to 14.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@
 
 import sys
 
-if sys.version_info < (3, 6):
-    raise RuntimeError('asyncpg requires Python 3.6 or greater')
+if sys.version_info < (3, 7):
+    raise RuntimeError('asyncpg requires Python 3.7 or greater')
 
 import os
 import os.path
@@ -30,7 +30,7 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 # Minimal dependencies required to test asyncpg.
 TEST_DEPENDENCIES = [
     'flake8~=5.0.4',
-    'uvloop>=0.15.3; platform_system != "Windows" and python_version >= "3.7"',
+    'uvloop>=0.15.3; platform_system != "Windows"',
 ]
 
 # Dependencies required to build documentation.
@@ -255,7 +255,6 @@ setuptools.setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -264,7 +263,7 @@ setuptools.setup(
         'Topic :: Database :: Front-Ends',
     ],
     platforms=['macOS', 'POSIX', 'Windows'],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     zip_safe=False,
     author='MagicStack Inc',
     author_email='hello@magic.io',

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -14,7 +14,6 @@ import platform
 import shutil
 import ssl
 import stat
-import sys
 import tempfile
 import textwrap
 import unittest
@@ -1466,10 +1465,6 @@ class TestSSLConnection(BaseTestSSLConnection):
             finally:
                 await con.close()
 
-    @unittest.skipIf(
-        sys.version_info < (3, 7),
-        "Python < 3.7 doesn't have ssl.TLSVersion"
-    )
     async def test_tls_version(self):
         if self.cluster.get_pg_version() < (12, 0):
             self.skipTest("PostgreSQL < 12 cannot set ssl protocol version")

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -10,7 +10,6 @@ import inspect
 import os
 import platform
 import random
-import sys
 import textwrap
 import time
 import unittest
@@ -741,7 +740,6 @@ class TestPool(tb.ConnectedTestCase):
                         self.assertEqual(pool.get_size(), 3)
                         self.assertEqual(pool.get_idle_size(), 0)
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)
@@ -763,7 +761,6 @@ class TestPool(tb.ConnectedTestCase):
                 async for _ in iterate(con):  # noqa
                     raise MyException()
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_transaction_exit_in_asyncgen_2(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)
@@ -788,7 +785,6 @@ class TestPool(tb.ConnectedTestCase):
 
             del iterator
 
-    @unittest.skipIf(sys.version_info[:2] < (3, 6), 'no asyncgen support')
     async def test_pool_handles_asyncgen_finalization(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)


### PR DESCRIPTION
Python 3.6 reached end-of-life [back in December](https://peps.python.org/pep-0494/#lifespan). Since 0.26.0 was just released with support for 3.6, the next release should probably drop support for it.
