### PR TITLE
Add support for `WHERE` clause in `copy_to` methods

### DIFF
--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -12,9 +12,10 @@ import textwrap
 
 __all__ = ('PostgresError', 'FatalPostgresError', 'UnknownPostgresError',
            'InterfaceError', 'InterfaceWarning', 'PostgresLogMessage',
+           'ClientConfigurationError',
            'InternalClientError', 'OutdatedSchemaCacheError', 'ProtocolError',
            'UnsupportedClientFeatureError', 'TargetServerAttributeNotMatched',
-           'ClientConfigurationError')
+           'UnsupportedServerFeatureError')
 
 
 def _is_asyncpg_class(cls):
@@ -231,6 +232,10 @@ class DataError(InterfaceError, ValueError):
 
 class UnsupportedClientFeatureError(InterfaceError):
     """Requested feature is unsupported by asyncpg."""
+
+
+class UnsupportedServerFeatureError(InterfaceError):
+    """Requested feature is unsupported by PostgreSQL server."""
 
 
 class InterfaceWarning(InterfaceMessage, UserWarning):

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -711,7 +711,8 @@ class Pool:
         force_quote=None,
         force_not_null=None,
         force_null=None,
-        encoding=None
+        encoding=None,
+        where=None
     ):
         """Copy data to the specified table.
 
@@ -740,7 +741,8 @@ class Pool:
                 force_quote=force_quote,
                 force_not_null=force_not_null,
                 force_null=force_null,
-                encoding=encoding
+                encoding=encoding,
+                where=where
             )
 
     async def copy_records_to_table(
@@ -750,7 +752,8 @@ class Pool:
         records,
         columns=None,
         schema_name=None,
-        timeout=None
+        timeout=None,
+        where=None
     ):
         """Copy a list of records to the specified table using binary COPY.
 
@@ -767,7 +770,8 @@ class Pool:
                 records=records,
                 columns=columns,
                 schema_name=schema_name,
-                timeout=timeout
+                timeout=timeout,
+                where=where
             )
 
     def acquire(self, *, timeout=None):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -10,6 +10,7 @@ import datetime
 import io
 import os
 import tempfile
+import unittest
 
 import asyncpg
 from asyncpg import _testbase as tb
@@ -414,7 +415,7 @@ class TestCopyTo(tb.ConnectedTestCase):
                     '*a4*|b4',
                     '*a5*|b5',
                     '*!**|*n-u-l-l*',
-                    'n-u-l-l|bb'
+                    'n-u-l-l|bb',
                 ]).encode('utf-8')
             )
             f.seek(0)
@@ -644,6 +645,35 @@ class TestCopyTo(tb.ConnectedTestCase):
         finally:
             await self.con.execute('DROP TABLE copytab')
 
+    async def test_copy_records_to_table_where(self):
+        if not self.con._server_caps.sql_copy_from_where:
+            raise unittest.SkipTest(
+                'COPY WHERE not supported on server')
+
+        await self.con.execute('''
+            CREATE TABLE copytab_where(a text, b int, c timestamptz);
+        ''')
+
+        try:
+            date = datetime.datetime.now(tz=datetime.timezone.utc)
+            delta = datetime.timedelta(days=1)
+
+            records = [
+                ('a-{}'.format(i), i, date + delta)
+                for i in range(100)
+            ]
+
+            records.append(('a-100', None, None))
+            records.append(('b-999', None, None))
+
+            res = await self.con.copy_records_to_table(
+                'copytab_where', records=records, where='a <> \'b-999\'')
+
+            self.assertEqual(res, 'COPY 101')
+
+        finally:
+            await self.con.execute('DROP TABLE copytab_where')
+
     async def test_copy_records_to_table_async(self):
         await self.con.execute('''
             CREATE TABLE copytab_async(a text, b int, c timestamptz);
@@ -660,7 +690,8 @@ class TestCopyTo(tb.ConnectedTestCase):
                 yield ('a-100', None, None)
 
             res = await self.con.copy_records_to_table(
-                'copytab_async', records=record_generator())
+                'copytab_async', records=record_generator(),
+            )
 
             self.assertEqual(res, 'COPY 101')
 


### PR DESCRIPTION
Hi there,

This PR closes issue #939, and adds support for a `where` parameter in the `copy_to` family of methods. It is not a breaking change and will not affect existing code. Apologies for the delay - work has been pretty crazy the past couple days.

There are a couple things I'm unsure of here and wanted to flag:
- Is the addition of `UnsupportedServerFeatureError` warranted? The existing exception types didn't seem like a good fit, but maybe this is too much of a special case to warrant its own.
- Is raising an exception the desired behavior on unsupported Postgres versions? I don't really see a reasonable way to "backport" this behavior in order to avoid an exception, but maybe I'm missing something.
  - There _is_ the option of issuing a warning instead, and allowing the inevitable syntax error to bubble up. But that feels a bit convoluted to me and isn't something I like.

If anything here looks off, please let me know. Thanks!