### PR TITLE
Add arm64 mac and linux wheels

### DIFF
--- a/.github/workflows/install-postgres.sh
+++ b/.github/workflows/install-postgres.sh
@@ -27,11 +27,16 @@ if [ "${ID}" = "debian" -o "${ID}" = "ubuntu" ]; then
     apt-get install -y --no-install-recommends \
         "postgresql-${PGVERSION}" \
         "postgresql-contrib-${PGVERSION}"
+elif [ "${ID}" = "almalinux" ]; then
+    yum install -y \
+        "postgresql-server" \
+        "postgresql-devel" \
+        "postgresql-contrib"
 elif [ "${ID}" = "centos" ]; then
-    el="EL-${VERSION_ID}-$(arch)"
+    el="EL-${VERSION_ID%.*}-$(arch)"
     baseurl="https://download.postgresql.org/pub/repos/yum/reporpms"
     yum install -y "${baseurl}/${el}/pgdg-redhat-repo-latest.noarch.rpm"
-    if [ ${VERSION_ID} -ge 8 ]; then
+    if [ ${VERSION_ID%.*} -ge 8 ]; then
         dnf -qy module disable postgresql
     fi
     yum install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,16 +71,25 @@ jobs:
   build-wheels:
     needs: validate-release-request
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        cibw_python: ["cp36-*", "cp37-*", "cp38-*", "cp39-*", "cp310-*"]
-        cibw_arch: ["auto64", "auto32"]
-        exclude:
-          - os: macos-latest
-            cibw_arch: "auto32"
-          - os: ubuntu-latest
-            cibw_arch: "auto32"
+        include:
+          - {os: macos-latest, arch: x86_64, build: "*"}
+          - {os: macos-latest, arch: arm64, build: "*"}
+          - {os: windows-latest, arch: AMD64, build: "*"}
+          - {os: windows-latest, arch: x86, build: "*"}
+          - {os: ubuntu-latest, arch: x86_64, build: "*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[61]-manylinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[72]-manylinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[83]-manylinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[94]-manylinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[05]-manylinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[61]-musllinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[72]-musllinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[83]-musllinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[94]-musllinux*"}
+          - {os: ubuntu-latest, arch: aarch64, build: "*[05]-musllinux*"}
 
     defaults:
       run:
@@ -94,12 +103,19 @@ jobs:
       with:
         fetch-depth: 50
         submodules: true
+        
+    - name: Set up QEMU
+      if: runner.os == 'Linux'
+      uses: docker/setup-qemu-action@v2
 
-    - uses: pypa/cibuildwheel@v2.8.0
+    - uses: pypa/cibuildwheel@v2.10.0
       env:
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_BUILD: ${{ matrix.cibw_python }}
-        CIBW_ARCHS: ${{ matrix.cibw_arch }}
+        CIBW_ARCHS: ${{ matrix.arch }}
+        CIBW_BUILD: ${{ matrix.build }}  # py versions from setup.py -> python_requires
+        CIBW_SKIP: pp*
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 
     - uses: actions/upload-artifact@v2
       with:
@@ -107,7 +123,7 @@ jobs:
         path: wheelhouse/*.whl
 
   publish-docs:
-    needs: validate-release-request
+    needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Build source distribution
       run: |
@@ -68,28 +68,35 @@ jobs:
         name: dist
         path: dist/*.tar.*
 
-  build-wheels:
+  build-wheels-matrix:
     needs: validate-release-request
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+      - run: pip install cibuildwheel==2.10.2
+      - id: set-matrix
+        run: |
+          MATRIX_INCLUDE=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": inputs, "os": "windows-latest"}'
+            } | jq -sc
+          )
+          echo ::set-output name=include::"$MATRIX_INCLUDE"
+
+  build-wheels:
+    needs: build-wheels-matrix
     runs-on: ${{ matrix.os }}
     continue-on-error: true
+    name: Build ${{ matrix.only }}
+
     strategy:
       matrix:
-        include:
-          - {os: macos-latest, arch: x86_64, build: "*"}
-          - {os: macos-latest, arch: arm64, build: "*"}
-          - {os: windows-latest, arch: AMD64, build: "*"}
-          - {os: windows-latest, arch: x86, build: "*"}
-          - {os: ubuntu-latest, arch: x86_64, build: "*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[61]-manylinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[72]-manylinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[83]-manylinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[94]-manylinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[05]-manylinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[61]-musllinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[72]-musllinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[83]-musllinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[94]-musllinux*"}
-          - {os: ubuntu-latest, arch: aarch64, build: "*[05]-musllinux*"}
+        include: ${{ fromJson(needs.build-wheels-matrix.outputs.include) }}
 
     defaults:
       run:
@@ -108,12 +115,11 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v2
 
-    - uses: pypa/cibuildwheel@v2.10.0
+    - uses: pypa/cibuildwheel@v2.10.2
+      with:
+        only: ${{ matrix.only }}
       env:
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_ARCHS: ${{ matrix.arch }}
-        CIBW_BUILD: ${{ matrix.build }}  # py versions from setup.py -> python_requires
-        CIBW_SKIP: pp*
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
 
@@ -137,7 +143,7 @@ jobs:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -12,7 +12,7 @@ from asyncpg import _testbase as tb
 from asyncpg import connection as apg_con
 
 
-MAX_RUNTIME = 0.1
+MAX_RUNTIME = 0.25
 
 
 class SlowIntrospectionConnection(apg_con.Connection):


### PR DESCRIPTION
Fixes #870 
Fixes #936 
Fixes #950

This PR:
- Adds a fair amount of parallellization ref https://github.com/pypa/cibuildwheel/issues/1088#issuecomment-1250024795
- Uses latest manylinux images (RHEL8.6) for building future-proof wheels: the default yum repo comes with pg10 (left it like that for simplicity in the install script)
- Automatically determines which python versions to build wheels for based on `setup.py`
- Avoids prematurely publishing new docs when building wheels could still fail
<img width="172" alt="image" src="https://user-images.githubusercontent.com/14880945/190850974-969fbb94-d3bb-4ac2-9d3e-677a2d6a179f.png">
