### PR TITLE
Exclude .venv from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402,E731,W503,W504,E252
-exclude = .git,__pycache__,build,dist,.eggs,.github,.local
+exclude = .git,__pycache__,build,dist,.eggs,.github,.local,.venv


### PR DESCRIPTION
Virtual environment directories are often named `.venv` by convention.