### PR TITLE
asyncpg v0.27.0

### DIFF
--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -10,4 +10,4 @@
 # supported platforms, publish the packages on PyPI, merge the PR
 # to the target branch, create a Git tag pointing to the commit.
 
-__version__ = '0.26.0'
+__version__ = '0.27.0'


### PR DESCRIPTION
Support Python 3.11 and PostgreSQL 15.  This release also drops support
for Python 3.6.

Changes
=======

* Add arm64 mac and linux wheels
  (by @ddelange in 7bd6c49f for #954)

* Add Python 3.11 to the test matrix
  (by @elprans in 5f908e67 for #948)

* Exclude .venv from flake8 (#958)
  (by @jparise in 40b16ea6 for #958)

* Upgrade to flake8 5.0.4 (from 3.9.2) (#961)
  (by @jparise in 0e73fec2 for #961)

* Show an example of a custom Record class (#960)
  (by @jparise in 84c99bfd for #960)

* Use the exact type name in Record.__repr__ (#959)
  (by @jparise in eccdf61a for #959)

* Drop Python 3.6 support (#940)
  (by @bryanforbes in bb0cb39d for #940)

* Test on Python 3.11 and PostgreSQL 15, fix workflow deprecations (#968)
  (by @elprans in eab7fdf2 for #968)