### PR TITLE
Add Pool.is_closing() method

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -446,13 +446,12 @@ class Pool:
 
                 await asyncio.gather(*connect_tasks)
 
-    @property
-    def closed(self):
+    def is_closed(self):
         """Return a boolean for whether this pool has already been closed/terminated.
 
         .. versionadded:: 0.28.0
         """
-        return self._closed
+        return self._closed or self._closing
 
     def get_size(self):
         """Return the current number of connections in this pool.

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -446,8 +446,8 @@ class Pool:
 
                 await asyncio.gather(*connect_tasks)
 
-    def is_closed(self):
-        """Return a boolean for whether this pool has already been closed/terminated.
+    def is_closing(self):
+        """Return ``True`` if the pool is closing or is closed.
 
         .. versionadded:: 0.28.0
         """

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -446,6 +446,14 @@ class Pool:
 
                 await asyncio.gather(*connect_tasks)
 
+    @property
+    def closed(self):
+        """Return a boolean for whether this pool has already been closed/terminated.
+
+        .. versionadded:: 0.28.0
+        """
+        return self._closed
+
     def get_size(self):
         """Return the current number of connections in this pool.
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -740,6 +740,17 @@ class TestPool(tb.ConnectedTestCase):
                         self.assertEqual(pool.get_size(), 3)
                         self.assertEqual(pool.get_idle_size(), 0)
 
+    async def test_pool_closed(self):
+        async with self.create_pool() as pool:
+            self.assertFalse(pool.closed)
+            await pool.close()
+            self.assertTrue(pool.closed)
+
+        async with self.create_pool() as pool:
+            self.assertFalse(pool.closed)
+            await pool.terminate()
+            self.assertTrue(pool.closed)
+
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',
                                       min_size=1, max_size=1)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -748,7 +748,7 @@ class TestPool(tb.ConnectedTestCase):
 
         async with self.create_pool() as pool:
             self.assertFalse(pool.is_closing())
-            await pool.terminate()
+            pool.terminate()
             self.assertTrue(pool.is_closing())
 
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -740,16 +740,16 @@ class TestPool(tb.ConnectedTestCase):
                         self.assertEqual(pool.get_size(), 3)
                         self.assertEqual(pool.get_idle_size(), 0)
 
-    async def test_pool_closed(self):
+    async def test_pool_closing(self):
         async with self.create_pool() as pool:
-            self.assertFalse(pool.is_closed())
+            self.assertFalse(pool.is_closing())
             await pool.close()
-            self.assertTrue(pool.is_closed())
+            self.assertTrue(pool.is_closing())
 
         async with self.create_pool() as pool:
-            self.assertFalse(pool.is_closed())
+            self.assertFalse(pool.is_closing())
             await pool.terminate()
-            self.assertTrue(pool.is_closed())
+            self.assertTrue(pool.is_closing())
 
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -742,14 +742,14 @@ class TestPool(tb.ConnectedTestCase):
 
     async def test_pool_closed(self):
         async with self.create_pool() as pool:
-            self.assertFalse(pool.closed)
+            self.assertFalse(pool.is_closed())
             await pool.close()
-            self.assertTrue(pool.closed)
+            self.assertTrue(pool.is_closed())
 
         async with self.create_pool() as pool:
-            self.assertFalse(pool.closed)
+            self.assertFalse(pool.is_closed())
             await pool.terminate()
-            self.assertTrue(pool.closed)
+            self.assertTrue(pool.is_closed())
 
     async def test_pool_handles_transaction_exit_in_asyncgen_1(self):
         pool = await self.create_pool(database='postgres',


### PR DESCRIPTION
Sometimes, application code wants to check if a `Pool` is still open or not. This adds an `is_closing()` method to the public API for `Pool`, so that it's easy to do so.