### PR TITLE
Do not try to cleanup anonymous statements

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1416,6 +1416,7 @@ class Connection(metaclass=ConnectionMeta):
     def _maybe_gc_stmt(self, stmt):
         if (
             stmt.refs == 0
+            and stmt.name
             and not self._stmt_cache.has(
                 (stmt.query, stmt.record_class, stmt.ignore_custom_codec)
             )


### PR DESCRIPTION
This supports a case where we prepare an unnamed statement to inspect the return types. The statement should not be cleaned up afterwards because it is automatically cleaned up by Postgres

Fixes: #982