### PR TITLE
Target session attr (2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,13 +17,10 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:
-          # uvloop does not support Python 3.6
-          - loop: uvloop
-            python-version: "3.6"
           # uvloop does not support windows
           - loop: uvloop
             os: windows-latest
@@ -38,7 +35,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
@@ -54,7 +51,7 @@ jobs:
           __version__\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: steps.release.outputs.version == 0
       with:
         python-version: ${{ matrix.python-version }}
@@ -79,7 +76,7 @@ jobs:
   test-postgres:
     strategy:
       matrix:
-        postgres-version: ["9.5", "9.6", "10", "11", "12", "13", "14"]
+        postgres-version: ["9.5", "9.6", "10", "11", "12", "13", "14", "15"]
 
     runs-on: ubuntu-latest
 
@@ -87,7 +84,7 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 50
         submodules: true
@@ -114,8 +111,10 @@ jobs:
           >> "${GITHUB_ENV}"
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       if: steps.release.outputs.version == 0
+      with:
+        python-version: "3.x"
 
     - name: Install Python Deps
       if: steps.release.outputs.version == 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:

--- a/asyncpg/_testbase/__init__.py
+++ b/asyncpg/_testbase/__init__.py
@@ -438,6 +438,7 @@ class ConnectedTestCase(ClusterTestCase):
 
 
 class HotStandbyTestCase(ClusterTestCase):
+
     @classmethod
     def setup_cluster(cls):
         cls.master_cluster = cls.new_cluster(pg_cluster.TempCluster)

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -13,6 +13,7 @@ import getpass
 import os
 import pathlib
 import platform
+import random
 import re
 import socket
 import ssl as ssl_module
@@ -56,6 +57,7 @@ _ConnectionParameters = collections.namedtuple(
         'direct_tls',
         'connect_timeout',
         'server_settings',
+        'target_session_attribute',
     ])
 
 
@@ -259,7 +261,8 @@ def _dot_postgresql_path(filename) -> pathlib.Path:
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                                 password, passfile, database, ssl,
-                                direct_tls, connect_timeout, server_settings):
+                                direct_tls, connect_timeout, server_settings,
+                                target_session_attribute):
     # `auth_hosts` is the version of host information for the purposes
     # of reading the pgpass file.
     auth_hosts = None
@@ -603,7 +606,8 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
     params = _ConnectionParameters(
         user=user, password=password, database=database, ssl=ssl,
         sslmode=sslmode, direct_tls=direct_tls,
-        connect_timeout=connect_timeout, server_settings=server_settings)
+        connect_timeout=connect_timeout, server_settings=server_settings,
+        target_session_attribute=target_session_attribute)
 
     return addrs, params
 
@@ -613,8 +617,8 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
                              statement_cache_size,
                              max_cached_statement_lifetime,
                              max_cacheable_statement_size,
-                             ssl, direct_tls, server_settings):
-
+                             ssl, direct_tls, server_settings,
+                             target_session_attribute):
     local_vars = locals()
     for var_name in {'max_cacheable_statement_size',
                      'max_cached_statement_lifetime',
@@ -642,7 +646,8 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
         dsn=dsn, host=host, port=port, user=user,
         password=password, passfile=passfile, ssl=ssl,
         direct_tls=direct_tls, database=database,
-        connect_timeout=timeout, server_settings=server_settings)
+        connect_timeout=timeout, server_settings=server_settings,
+        target_session_attribute=target_session_attribute)
 
     config = _ClientConfiguration(
         command_timeout=command_timeout,
@@ -875,18 +880,64 @@ async def __connect_addr(
     return con
 
 
+class SessionAttribute(str, enum.Enum):
+    any = 'any'
+    primary = 'primary'
+    standby = 'standby'
+    prefer_standby = 'prefer-standby'
+
+
+def _accept_in_hot_standby(should_be_in_hot_standby: bool):
+    """
+    If the server didn't report "in_hot_standby" at startup, we must determine
+    the state by checking "SELECT pg_catalog.pg_is_in_recovery()".
+    """
+    async def can_be_used(connection):
+        settings = connection.get_settings()
+        hot_standby_status = getattr(settings, 'in_hot_standby', None)
+        if hot_standby_status is not None:
+            is_in_hot_standby = hot_standby_status == 'on'
+        else:
+            is_in_hot_standby = await connection.fetchval(
+                "SELECT pg_catalog.pg_is_in_recovery()"
+            )
+
+        return is_in_hot_standby == should_be_in_hot_standby
+
+    return can_be_used
+
+
+async def _accept_any(_):
+    return True
+
+
+target_attrs_check = {
+    SessionAttribute.any: _accept_any,
+    SessionAttribute.primary: _accept_in_hot_standby(False),
+    SessionAttribute.standby: _accept_in_hot_standby(True),
+    SessionAttribute.prefer_standby: _accept_in_hot_standby(True),
+}
+
+
+async def _can_use_connection(connection, attr: SessionAttribute):
+    can_use = target_attrs_check[attr]
+    return await can_use(connection)
+
+
 async def _connect(*, loop, timeout, connection_class, record_class, **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
 
     addrs, params, config = _parse_connect_arguments(timeout=timeout, **kwargs)
+    target_attr = params.target_session_attribute
 
+    candidates = []
+    chosen_connection = None
     last_error = None
-    addr = None
     for addr in addrs:
         before = time.monotonic()
         try:
-            return await _connect_addr(
+            conn = await _connect_addr(
                 addr=addr,
                 loop=loop,
                 timeout=timeout,
@@ -895,12 +946,30 @@ async def _connect(*, loop, timeout, connection_class, record_class, **kwargs):
                 connection_class=connection_class,
                 record_class=record_class,
             )
+            candidates.append(conn)
+            if await _can_use_connection(conn, target_attr):
+                chosen_connection = conn
+                break
         except (OSError, asyncio.TimeoutError, ConnectionError) as ex:
             last_error = ex
         finally:
             timeout -= time.monotonic() - before
+    else:
+        if target_attr == SessionAttribute.prefer_standby and candidates:
+            chosen_connection = random.choice(candidates)
 
-    raise last_error
+    await asyncio.gather(
+        (c.close() for c in candidates if c is not chosen_connection),
+        return_exceptions=True
+    )
+
+    if chosen_connection:
+        return chosen_connection
+
+    raise last_error or exceptions.TargetServerAttributeNotMatched(
+        'None of the hosts match the target attribute requirement '
+        '{!r}'.format(target_attr)
+    )
 
 
 async def _cancel(*, loop, addr, params: _ConnectionParameters,

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -917,18 +917,11 @@ def _accept_read_only(should_be_read_only: bool):
     """
     async def can_be_used(connection):
         settings = connection.get_settings()
-        is_read_only = getattr(settings, 'default_transaction_read_only', None)
-        if is_read_only is not None:
-            is_read_only = is_read_only == "on"
-        else:
-            is_read_only = False
-        if should_be_read_only:
-            if is_read_only:
-                return True
-            elif await _accept_in_hot_standby(True)(connection):
-                return True
-            return False
-        return _accept_in_hot_standby(False)(connection)
+        is_read_only = getattr(settings, 'default_transaction_read_only', 'off')
+
+        if should_be_read_only and is_read_only == "on":
+            return True
+        return await _accept_in_hot_standby(should_be_read_only)(connection)
     return can_be_used
 
 

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -10,7 +10,6 @@ import collections
 import enum
 import functools
 import getpass
-import logging
 import os
 import pathlib
 import platform
@@ -30,8 +29,6 @@ import inspect
 from . import compat
 from . import exceptions
 from . import protocol
-
-logger = logging.getLogger(__name__)
 
 
 class SSLMode(enum.IntEnum):
@@ -907,10 +904,6 @@ def _accept_in_hot_standby(should_be_in_hot_standby: bool):
                 "SELECT pg_catalog.pg_is_in_recovery()"
             )
         connection_eligible = is_in_hot_standby == should_be_in_hot_standby
-        logger.debug(
-            "Connection {!r} eligible=({!r}). Allow hot standby={!r}".
-            format(connection, connection_eligible, should_be_in_hot_standby)
-        )
         return connection_eligible
 
     return can_be_used

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -33,6 +33,7 @@ from . import protocol
 
 logger = logging.getLogger(__name__)
 
+
 class SSLMode(enum.IntEnum):
     disable = 0
     allow = 1
@@ -904,10 +905,14 @@ def _accept_in_hot_standby(should_be_in_hot_standby: bool):
                 "SELECT pg_catalog.pg_is_in_recovery()"
             )
             if is_in_recovery:
-                logger.warning("Connection {!r} is still in recovery mode".format(connection))
+                logger.warning("Connection {!r} is still in recovery mode"
+                               .format(connection))
             is_in_hot_standby = not is_in_recovery
         connection_eligible = is_in_hot_standby == should_be_in_hot_standby
-        logger.debug("Connection {!r} is eligible ({!r}). Allow".format(connection, connection_eligible))
+        logger.debug(
+            "Connection {!r} eligible=({!r}). Allow hot standby={!r}".
+            format(connection, connection_eligible, should_be_in_hot_standby)
+        )
         return connection_eligible
 
     return can_be_used

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -917,9 +917,9 @@ def _accept_read_only(should_be_read_only: bool):
     """
     async def can_be_used(connection):
         settings = connection.get_settings()
-        is_read_only = getattr(settings, 'default_transaction_read_only', 'off')
+        is_readonly = getattr(settings, 'default_transaction_read_only', 'off')
 
-        if should_be_read_only and is_read_only == "on":
+        if should_be_read_only and is_readonly == "on":
             return True
         return await _accept_in_hot_standby(should_be_read_only)(connection)
     return can_be_used

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -30,6 +30,7 @@ from . import protocol
 from . import serverversion
 from . import transaction
 from . import utils
+from .connect_utils import SessionAttribute
 
 
 class ConnectionMeta(type):
@@ -1792,7 +1793,8 @@ async def connect(dsn=None, *,
                   direct_tls=False,
                   connection_class=Connection,
                   record_class=protocol.Record,
-                  server_settings=None):
+                  server_settings=None,
+                  target_session_attribute=SessionAttribute.any):
     r"""A coroutine to establish a connection to a PostgreSQL server.
 
     The connection parameters may be specified either as a connection
@@ -2003,6 +2005,16 @@ async def connect(dsn=None, *,
         this connection object.  Must be a subclass of
         :class:`~asyncpg.Record`.
 
+    :param SessionAttribute target_session_attribute:
+        If specified, check that the host has the correct attribute.
+        Can be one of:
+            "any": the first successfully connected host
+            "primary": the host must NOT be in hot standby mode
+            "standby": the host must be in hot standby mode
+            "prefer-standby": first try to find a standby host, but if
+                            none of the listed hosts is a standby server,
+                            return any of them.
+
     :return: A :class:`~asyncpg.connection.Connection` instance.
 
     Example:
@@ -2087,6 +2099,15 @@ async def connect(dsn=None, *,
     if record_class is not protocol.Record:
         _check_record_class(record_class)
 
+    try:
+        target_session_attribute = SessionAttribute(target_session_attribute)
+    except ValueError as exc:
+        raise exceptions.InterfaceError(
+            "target_session_attribute is expected to be one of "
+            "'any', 'primary', 'standby' or 'prefer-standby'"
+            ", got {!r}".format(target_session_attribute)
+        ) from exc
+
     if loop is None:
         loop = asyncio.get_event_loop()
 
@@ -2109,6 +2130,7 @@ async def connect(dsn=None, *,
         statement_cache_size=statement_cache_size,
         max_cached_statement_lifetime=max_cached_statement_lifetime,
         max_cacheable_statement_size=max_cacheable_statement_size,
+        target_session_attribute=target_session_attribute
     )
 
 

--- a/asyncpg/exceptions/_base.py
+++ b/asyncpg/exceptions/_base.py
@@ -13,7 +13,7 @@ import textwrap
 __all__ = ('PostgresError', 'FatalPostgresError', 'UnknownPostgresError',
            'InterfaceError', 'InterfaceWarning', 'PostgresLogMessage',
            'InternalClientError', 'OutdatedSchemaCacheError', 'ProtocolError',
-           'UnsupportedClientFeatureError')
+           'UnsupportedClientFeatureError', 'TargetServerAttributeNotMatched')
 
 
 def _is_asyncpg_class(cls):
@@ -242,6 +242,10 @@ class InternalClientError(Exception):
 
 class ProtocolError(InternalClientError):
     """Unexpected condition in the handling of PostgreSQL protocol input."""
+
+
+class TargetServerAttributeNotMatched(InternalClientError):
+    """Could not find a host that satisfies the target attribute requirement"""
 
 
 class OutdatedSchemaCacheError(InternalClientError):

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@
 
 import sys
 
-if sys.version_info < (3, 6):
-    raise RuntimeError('asyncpg requires Python 3.6 or greater')
+if sys.version_info < (3, 7):
+    raise RuntimeError('asyncpg requires Python 3.7 or greater')
 
 import os
 import os.path
@@ -29,12 +29,8 @@ CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
 
 # Minimal dependencies required to test asyncpg.
 TEST_DEPENDENCIES = [
-    # pycodestyle is a dependency of flake8, but it must be frozen because
-    # their combination breaks too often
-    # (example breakage: https://gitlab.com/pycqa/flake8/issues/427)
-    'pycodestyle~=2.7.0',
-    'flake8~=3.9.2',
-    'uvloop>=0.15.3; platform_system != "Windows" and python_version >= "3.7"',
+    'flake8~=5.0.4',
+    'uvloop>=0.15.3; platform_system != "Windows"',
 ]
 
 # Dependencies required to build documentation.
@@ -259,7 +255,6 @@ setuptools.setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -268,7 +263,7 @@ setuptools.setup(
         'Topic :: Database :: Front-Ends',
     ],
     platforms=['macOS', 'POSIX', 'Windows'],
-    python_requires='>=3.6.0',
+    python_requires='>=3.7.0',
     zip_safe=False,
     author='MagicStack Inc',
     author_email='hello@magic.io',

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1806,6 +1806,7 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         await con.close()
 
 
+
 def _get_connected_host(con):
     peername = con._transport.get_extra_info('peername')
     if isinstance(peername, tuple):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1772,6 +1772,17 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
             await self._run_connection_test(
                 connect, target_attr, expected_port
             )
+        if self.master_cluster.get_pg_version()[0] < 14:
+            self.skipTest("PostgreSQL<14 does not support these features")
+        tests = [
+            (self.connect_primary, 'read-write', master_port),
+            (self.connect_standby, 'read-only', standby_port),
+        ]
+
+        for connect, target_attr, expected_port in tests:
+            await self._run_connection_test(
+                connect, target_attr, expected_port
+            )
 
     async def test_target_attribute_not_matched(self):
         if self.master_cluster.get_pg_version()[0] == 11:
@@ -1779,6 +1790,17 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         tests = [
             (self.connect_standby, 'primary'),
             (self.connect_primary, 'standby'),
+        ]
+
+        for connect, target_attr in tests:
+            with self.assertRaises(exceptions.TargetServerAttributeNotMatched):
+                await connect(target_session_attribute=target_attr)
+
+        if self.master_cluster.get_pg_version()[0] < 14:
+            self.skipTest("PostgreSQL<14 does not support these features")
+        tests = [
+            (self.connect_standby, 'read-write'),
+            (self.connect_primary, 'read-only'),
         ]
 
         for connect, target_attr in tests:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1464,7 +1464,7 @@ class TestSSLConnection(BaseTestSSLConnection):
             )
         finally:
             try:
-                await con.execute('DROP TABLE test_many')
+                await con.execute('DROP TABLE IF EXISTS test_many')
             finally:
                 await con.close()
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1757,7 +1757,7 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         await conn.close()
 
     async def test_target_server_attribute_port(self):
-        if self.cluster.get_pg_version()[0] == 11:
+        if self.master_cluster.get_pg_version()[0] == 11:
             self.skipTest("PostgreSQL 11 seems to have issues with this test")
         master_port = self.master_cluster.get_connection_spec()['port']
         standby_port = self.standby_cluster.get_connection_spec()['port']
@@ -1772,7 +1772,7 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
             )
 
     async def test_target_attribute_not_matched(self):
-        if self.cluster.get_pg_version()[0] == 11:
+        if self.master_cluster.get_pg_version()[0] == 11:
             self.skipTest("PostgreSQL 11 seems to have issues with this test")
         tests = [
             (self.connect_standby, 'primary'),
@@ -1784,7 +1784,7 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
                 await connect(target_session_attribute=target_attr)
 
     async def test_prefer_standby_when_standby_is_up(self):
-        if self.cluster.get_pg_version()[0] == 11:
+        if self.master_cluster.get_pg_version()[0] == 11:
             self.skipTest("PostgreSQL 11 seems to have issues with this test")
         con = await self.connect(target_session_attribute='prefer-standby')
         standby_port = self.standby_cluster.get_connection_spec()['port']
@@ -1793,6 +1793,8 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         await con.close()
 
     async def test_prefer_standby_picks_master_when_standby_is_down(self):
+        if self.master_cluster.get_pg_version()[0] == 11:
+            self.skipTest("PostgreSQL 11 seems to have issues with this test")
         primary_spec = self.get_cluster_connection_spec(self.master_cluster)
         connection_spec = {
             'host': [

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1806,7 +1806,6 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         await con.close()
 
 
-
 def _get_connected_host(con):
     peername = con._transport.get_extra_info('peername')
     if isinstance(peername, tuple):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1290,6 +1290,7 @@ class BaseTestSSLConnection(tb.ConnectedTestCase):
 
         create_script = []
         create_script.append('CREATE ROLE ssl_user WITH LOGIN;')
+        create_script.append('GRANT ALL ON SCHEMA public TO ssl_user;')
 
         self._add_hba_entry()
 
@@ -1304,6 +1305,7 @@ class BaseTestSSLConnection(tb.ConnectedTestCase):
         self.cluster.trust_local_connections()
 
         drop_script = []
+        drop_script.append('REVOKE ALL ON SCHEMA public FROM ssl_user;')
         drop_script.append('DROP ROLE ssl_user;')
         drop_script = '\n'.join(drop_script)
         self.loop.run_until_complete(self.con.execute(drop_script))

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1740,7 +1740,7 @@ class TestConnectionGC(tb.ClusterTestCase):
                                        r'unclosed connection') as rw:
                 await self._run_no_explicit_close_test()
 
-            msg = rw.warning.args[0]
+            msg = " ".join(rw.warning.args)
             self.assertIn(' created at:\n', msg)
             self.assertIn('in test_no_explicit_close_with_debug', msg)
         finally:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1757,6 +1757,8 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
         await conn.close()
 
     async def test_target_server_attribute_port(self):
+        if self.cluster.get_pg_version()[0] == 11:
+            self.skipTest("PostgreSQL 11 seems to have issues with this test")
         master_port = self.master_cluster.get_connection_spec()['port']
         standby_port = self.standby_cluster.get_connection_spec()['port']
         tests = [
@@ -1770,6 +1772,8 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
             )
 
     async def test_target_attribute_not_matched(self):
+        if self.cluster.get_pg_version()[0] == 11:
+            self.skipTest("PostgreSQL 11 seems to have issues with this test")
         tests = [
             (self.connect_standby, 'primary'),
             (self.connect_primary, 'standby'),
@@ -1780,6 +1784,8 @@ class TestConnectionAttributes(tb.HotStandbyTestCase):
                 await connect(target_session_attribute=target_attr)
 
     async def test_prefer_standby_when_standby_is_up(self):
+        if self.cluster.get_pg_version()[0] == 11:
+            self.skipTest("PostgreSQL 11 seems to have issues with this test")
         con = await self.connect(target_session_attribute='prefer-standby')
         standby_port = self.standby_cluster.get_connection_spec()['port']
         connected_host = _get_connected_host(con)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -18,7 +18,6 @@ import unittest
 import asyncpg
 from asyncpg import _testbase as tb
 from asyncpg import connection as pg_connection
-from asyncpg import cluster as pg_cluster
 from asyncpg import pool as pg_pool
 
 _system = platform.uname().system
@@ -964,52 +963,7 @@ class TestPool(tb.ConnectedTestCase):
 
 
 @unittest.skipIf(os.environ.get('PGHOST'), 'using remote cluster for testing')
-class TestHotStandby(tb.ClusterTestCase):
-    @classmethod
-    def setup_cluster(cls):
-        cls.master_cluster = cls.new_cluster(pg_cluster.TempCluster)
-        cls.start_cluster(
-            cls.master_cluster,
-            server_settings={
-                'max_wal_senders': 10,
-                'wal_level': 'hot_standby'
-            }
-        )
-
-        con = None
-
-        try:
-            con = cls.loop.run_until_complete(
-                cls.master_cluster.connect(
-                    database='postgres', user='postgres', loop=cls.loop))
-
-            cls.loop.run_until_complete(
-                con.execute('''
-                    CREATE ROLE replication WITH LOGIN REPLICATION
-                '''))
-
-            cls.master_cluster.trust_local_replication_by('replication')
-
-            conn_spec = cls.master_cluster.get_connection_spec()
-
-            cls.standby_cluster = cls.new_cluster(
-                pg_cluster.HotStandbyCluster,
-                cluster_kwargs={
-                    'master': conn_spec,
-                    'replication_user': 'replication'
-                }
-            )
-            cls.start_cluster(
-                cls.standby_cluster,
-                server_settings={
-                    'hot_standby': True
-                }
-            )
-
-        finally:
-            if con is not None:
-                cls.loop.run_until_complete(con.close())
-
+class TestHotStandby(tb.HotStandbyTestCase):
     def create_pool(self, **kwargs):
         conn_spec = self.standby_cluster.get_connection_spec()
         conn_spec.update(kwargs)


### PR DESCRIPTION
Recreating this PR because it seems to have gone silent.
The target is to implement the 
`target_session_attribute` keyword when connecting to a database cluster.
Supported options are
- any
- primary
- standy
- prefer_standby
- read-write
- read-only