### PR TITLE
Fix missing PyPI wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": inputs, "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": inputs, "os": "windows-latest"}'
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": ., "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": ., "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": ., "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,9 +85,9 @@ jobs:
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": ., "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -Rc '{"only": ., "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -Rc '{"only": ., "os": "windows-latest"}'
+              cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --arch x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --arch x86,AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
fix for #954 xref https://github.com/pypa/cibuildwheel/discussions/1261#discussioncomment-4734606
e.g. `cp36-manylinux_x86_64` was missing on pypi, because the first line was swallowed when using `inputs`:

```console
$ cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}'
{"only":"cp36-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp37-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp38-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp39-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp310-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp311-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp36-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp37-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp38-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp39-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp310-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp311-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp36-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp37-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp38-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp39-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp310-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp311-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp36-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp37-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp38-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp39-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp310-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp311-musllinux_aarch64","os":"ubuntu-latest"}
$ cibuildwheel --print-build-identifiers --platform linux --arch x86_64,aarch64 | grep cp |  jq -Rc '{"only": inputs, "os": "ubuntu-latest"}'
{"only":"cp37-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp38-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp39-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp310-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp311-manylinux_x86_64","os":"ubuntu-latest"}
{"only":"cp36-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp37-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp38-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp39-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp310-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp311-manylinux_aarch64","os":"ubuntu-latest"}
{"only":"cp36-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp37-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp38-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp39-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp310-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp311-musllinux_x86_64","os":"ubuntu-latest"}
{"only":"cp36-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp37-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp38-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp39-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp310-musllinux_aarch64","os":"ubuntu-latest"}
{"only":"cp311-musllinux_aarch64","os":"ubuntu-latest"}
```