### PR TITLE
remove outdated documentation on arbitrary args

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1811,8 +1811,7 @@ async def connect(dsn=None, *,
         The following options are recognized by asyncpg: ``host``,
         ``port``, ``user``, ``database`` (or ``dbname``), ``password``,
         ``passfile``, ``sslmode``, ``sslcert``, ``sslkey``, ``sslrootcert``,
-        and ``sslcrl``.  Unlike libpq, asyncpg will treat unrecognized
-        options as `server settings`_ to be used for the connection.
+        and ``sslcrl``. 
 
         .. note::
 


### PR DESCRIPTION
removed outdated docs regarding unknown params because that functionality was removed in an earlier version

> Changed in version 0.11.0: Removed ability to pass arbitrary keyword arguments to set server settings. Added a dedicated parameter server_settings for that.

I'm sad this was removed, now its a lot more difficult to set tcp_keepalives using sqlalchemy.