### PR TITLE
fix: salt and iterations parsing for scram

### DIFF
--- a/asyncpg/protocol/scram.pyx
+++ b/asyncpg/protocol/scram.pyx
@@ -156,12 +156,12 @@ cdef class SCRAMAuthentication:
         if not self.server_nonce.startswith(self.client_nonce):
             raise Exception("invalid nonce")
         try:
-            self.password_salt = re.search(b's=([^,]+),',
+            self.password_salt = re.search(b',s=([^,]+),',
                 self.server_first_message).group(1)
         except IndexError:
             raise Exception("could not get salt")
         try:
-            self.password_iterations = int(re.search(b'i=(\d+),?',
+            self.password_iterations = int(re.search(b',i=(\d+),?',
                 self.server_first_message).group(1))
         except (IndexError, TypeError, ValueError):
             raise Exception("could not get iterations")


### PR DESCRIPTION
According to RFC5802 server-first-message has the following form: _[reserved-mext ","] nonce "," salt "," iteration-count ["," extensions]_. Where nonce is a sequence of random printable ASCII characters excluding ','. So the nonce can potentially contain the substring "s=". In the previous version of parsing, the salt could be taken from the nonce part of the message because of that.

For instance, the server first message was **b'r=Cipys==4,s=c2FsdA==,i=4096'**, then the old parsing would have **b'=4'** as a salt, which is wrong. The same problem could be with iteration-count.