### PR TITLE
Add support for READ UNCOMMITTED

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -257,9 +257,9 @@ class Connection(metaclass=ConnectionMeta):
 
         :param isolation: Transaction isolation mode, can be one of:
                           `'serializable'`, `'repeatable_read'`,
-                          `'read_committed'`. If not specified, the behavior
-                          is up to the server and session, which is usually
-                          ``read_committed``.
+                          `'read_uncommitted'`, `'read_committed'`. If not
+                          specified, the behavior is up to the server and
+                          session, which is usually ``read_committed``.
 
         :param readonly: Specifies whether or not this transaction is
                          read-only.

--- a/asyncpg/transaction.py
+++ b/asyncpg/transaction.py
@@ -19,9 +19,15 @@ class TransactionState(enum.Enum):
     FAILED = 4
 
 
-ISOLATION_LEVELS = {'read_committed', 'serializable', 'repeatable_read'}
+ISOLATION_LEVELS = {
+    'read_committed',
+    'read_uncommitted',
+    'serializable',
+    'repeatable_read',
+}
 ISOLATION_LEVELS_BY_VALUE = {
     'read committed': 'read_committed',
+    'read uncommitted': 'read_uncommitted',
     'serializable': 'serializable',
     'repeatable read': 'repeatable_read',
 }
@@ -124,6 +130,8 @@ class Transaction(connresource.ConnectionResource):
             query = 'BEGIN'
             if self._isolation == 'read_committed':
                 query += ' ISOLATION LEVEL READ COMMITTED'
+            elif self._isolation == 'read_uncommitted':
+                query += ' ISOLATION LEVEL READ UNCOMMITTED'
             elif self._isolation == 'repeatable_read':
                 query += ' ISOLATION LEVEL REPEATABLE READ'
             elif self._isolation == 'serializable':

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -188,6 +188,7 @@ class TestTransaction(tb.ConnectedTestCase):
         isolation_levels = {
             None: default_isolation,
             'read_committed': 'read committed',
+            'read_uncommitted': 'read uncommitted',
             'repeatable_read': 'repeatable read',
             'serializable': 'serializable',
         }
@@ -214,6 +215,7 @@ class TestTransaction(tb.ConnectedTestCase):
         set_sql = 'SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL '
         isolation_levels = {
             'read_committed': 'read committed',
+            'read_uncommitted': 'read uncommitted',
             'repeatable_read': 'repeatable read',
             'serializable': 'serializable',
         }


### PR DESCRIPTION
Add support for "READ UNCOMMITTED" transaction isolation level.

This transaction isolation level can be useful for testing, and is [supported by PostgreSQL](https://www.postgresql.org/docs/current/sql-set-transaction.html).