### PR TITLE
Scale flake8 back to 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ github = "https://github.com/MagicStack/asyncpg"
 
 [project.optional-dependencies]
 test = [
-    'flake8~=6.0.0',
+    'flake8~=5.0',
     'uvloop>=0.15.3; platform_system != "Windows"',
 ]
 docs = [


### PR DESCRIPTION
Looks like later versions dropped Python 3.7 support
