### PR TITLE
Cut BaseProtocol circular reference on close.

### DIFF
--- a/asyncpg/protocol/protocol.pxd
+++ b/asyncpg/protocol/protocol.pxd
@@ -39,8 +39,6 @@ cdef class BaseProtocol(CoreProtocol):
         bint return_extra
         object create_future
         object timeout_handle
-        object timeout_callback
-        object completed_callback
         object conref
         type record_class
         bint is_reading

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -582,6 +582,7 @@ cdef class BaseProtocol(CoreProtocol):
         self._handle_waiter_on_connection_lost(None)
         self._terminate()
         self.transport.abort()
+        self.transport = None
 
     @cython.iterable_coroutine
     async def close(self, timeout):

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -614,6 +614,7 @@ cdef class BaseProtocol(CoreProtocol):
         # Ask the server to terminate the connection and wait for it
         # to drop.
         self.waiter = self._new_waiter(timeout)
+        self.timeout_callback = self.completed_callback = None
         self._terminate()
         try:
             await self.waiter
@@ -682,6 +683,7 @@ cdef class BaseProtocol(CoreProtocol):
                 exc.__cause__ = cause
             self.waiter.set_exception(exc)
         self.waiter = None
+        self.timeout_callback = self.completed_callback = None
 
     cdef _set_server_parameter(self, name, val):
         self.settings.add_setting(name, val)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1859,8 +1859,8 @@ class TestConnectionGC(tb.ClusterTestCase):
             self.assertIsNone(conref())
             self.assertTrue(proto.is_closed())
 
-            # tick event loop so asyncio.selector_events._SelectorSocketTransport
-            # has a chance to close itself and remove its reference to proto
+            # tick event loop; asyncio.selector_events._SelectorSocketTransport
+            # needs a chance to close itself and remove its reference to proto
             await asyncio.sleep(0)
             protoref = weakref.ref(proto)
             del proto


### PR DESCRIPTION
A bound method contains a reference to the instance it's bound to. Most of the time, bound methods are created lazily at access time by the descriptor protocol and discarded after calling. But saving a bound method as another attribute on the instance creates a long-lived cycle, here `.timeout_callback.__self__`, that needs to be explicitly broken if we don't want to wake up python's garbage collector to do it.

Without this change, the new assertion in the tests would fail, and `pytest --pdb` would show the bound methods `_on_timeout` and `_on_waiter_completed` at the end of `p gc.get_referrers(protoref())`.

Things I'm not too certain about:
- whether I got all of the codepaths that need to delete `.timeout_callback` and `.completed_callback`—I empirically seem to have covered my use case, but that's far from actually understanding what gets called when
- whether the test I modified is the right place to put the new assertion
- windows—I tested on both asyncio and uvloop, but only on linux