### PR TITLE
Fix: connection leak on TimeoutError in acquire

### DIFF
--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -58,8 +58,8 @@ async def wait_for(fut, timeout):
 
     try:
         return await asyncio.wait_for(fut, timeout)
-    except asyncio.CancelledError:
-        if fut.done():
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        if fut.done() and not fut.cancelled():
             return fut.result()
         else:
             raise


### PR DESCRIPTION
Should fix #955

On many concurrent requests sometimes TimeoutError raises, but acquire future is done
That leads to connection leak, cause connection not returns to pool