### PR TITLE
Don't raise a new CancelledError if the future was cancelled

### DIFF
--- a/asyncpg/compat.py
+++ b/asyncpg/compat.py
@@ -59,7 +59,7 @@ async def wait_for(fut, timeout):
     try:
         return await asyncio.wait_for(fut, timeout)
     except asyncio.CancelledError:
-        if fut.done():
+        if fut.done() and not fut.cancelled():
             return fut.result()
         else:
             raise


### PR DESCRIPTION
This way, the original cancel message, if any, is preserved. This fixes compatibility with AnyIO 4.0.0rc1 which relies on said cancel messages to determine whether it should swallow a cancellation exception or not.