### PR TITLE
Add support for tuple-format custom codecs on composite types

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -1154,6 +1154,9 @@ class Connection(metaclass=ConnectionMeta):
             | ``time with     | (``microseconds``,                          |
             | time zone``     | ``time zone offset in seconds``)            |
             +-----------------+---------------------------------------------+
+            | any composite   | Composite value elements                    |
+            | type            |                                             |
+            +-----------------+---------------------------------------------+
 
         :param encoder:
             Callable accepting a Python object as a single argument and
@@ -1208,6 +1211,10 @@ class Connection(metaclass=ConnectionMeta):
             The ``binary`` keyword argument was removed in favor of
             ``format``.
 
+        .. versionchanged:: 0.29.0
+            Custom codecs for composite types are now supported with
+            ``format='tuple'``.
+
         .. note::
 
            It is recommended to use the ``'binary'`` or ``'tuple'`` *format*
@@ -1218,11 +1225,28 @@ class Connection(metaclass=ConnectionMeta):
            codecs.
         """
         self._check_open()
+        settings = self._protocol.get_settings()
         typeinfo = await self._introspect_type(typename, schema)
-        if not introspection.is_scalar_type(typeinfo):
+        full_typeinfos = []
+        if introspection.is_scalar_type(typeinfo):
+            kind = 'scalar'
+        elif introspection.is_composite_type(typeinfo):
+            if format != 'tuple':
+                raise exceptions.UnsupportedClientFeatureError(
+                    'only tuple-format codecs can be used on composite types',
+                    hint="Use `set_type_codec(..., format='tuple')` and "
+                         "pass/interpret data as a Python tuple.  See an "
+                         "example at https://magicstack.github.io/asyncpg/"
+                         "current/usage.html#example-decoding-complex-types",
+                )
+            kind = 'composite'
+            full_typeinfos, _ = await self._introspect_types(
+                (typeinfo['oid'],), 10)
+        else:
             raise exceptions.InterfaceError(
-                'cannot use custom codec on non-scalar type {}.{}'.format(
-                    schema, typename))
+                f'cannot use custom codec on type {schema}.{typename}: '
+                f'it is neither a scalar type nor a composite type'
+            )
         if introspection.is_domain_type(typeinfo):
             raise exceptions.UnsupportedClientFeatureError(
                 'custom codecs on domain types are not supported',
@@ -1234,8 +1258,8 @@ class Connection(metaclass=ConnectionMeta):
             )
 
         oid = typeinfo['oid']
-        self._protocol.get_settings().add_python_codec(
-            oid, typename, schema, 'scalar',
+        settings.add_python_codec(
+            oid, typename, schema, full_typeinfos, kind,
             encoder, decoder, format)
 
         # Statement cache is no longer valid due to codec changes.

--- a/asyncpg/introspection.py
+++ b/asyncpg/introspection.py
@@ -286,3 +286,7 @@ def is_scalar_type(typeinfo) -> bool:
 
 def is_domain_type(typeinfo) -> bool:
     return typeinfo['kind'] == b'd'
+
+
+def is_composite_type(typeinfo) -> bool:
+    return typeinfo['kind'] == b'c'

--- a/asyncpg/protocol/codecs/base.pxd
+++ b/asyncpg/protocol/codecs/base.pxd
@@ -57,6 +57,7 @@ cdef class Codec:
 
         encode_func     c_encoder
         decode_func     c_decoder
+        Codec           base_codec
 
         object          py_encoder
         object          py_decoder
@@ -79,6 +80,7 @@ cdef class Codec:
               CodecType type, ServerDataFormat format,
               ClientExchangeFormat xformat,
               encode_func c_encoder, decode_func c_decoder,
+              Codec base_codec,
               object py_encoder, object py_decoder,
               Codec element_codec, tuple element_type_oids,
               object element_names, list element_codecs,
@@ -169,6 +171,7 @@ cdef class Codec:
                                 object decoder,
                                 encode_func c_encoder,
                                 decode_func c_decoder,
+                                Codec base_codec,
                                 ServerDataFormat format,
                                 ClientExchangeFormat xformat)
 

--- a/asyncpg/protocol/settings.pxd
+++ b/asyncpg/protocol/settings.pxd
@@ -18,7 +18,7 @@ cdef class ConnectionSettings(pgproto.CodecContext):
     cpdef get_text_codec(self)
     cpdef inline register_data_types(self, types)
     cpdef inline add_python_codec(
-        self, typeoid, typename, typeschema, typekind, encoder,
+        self, typeoid, typename, typeschema, typeinfos, typekind, encoder,
         decoder, format)
     cpdef inline remove_python_codec(
         self, typeoid, typename, typeschema)

--- a/asyncpg/protocol/settings.pyx
+++ b/asyncpg/protocol/settings.pyx
@@ -36,7 +36,8 @@ cdef class ConnectionSettings(pgproto.CodecContext):
         self._data_codecs.add_types(types)
 
     cpdef inline add_python_codec(self, typeoid, typename, typeschema,
-                                  typekind, encoder, decoder, format):
+                                  typeinfos, typekind, encoder, decoder,
+                                  format):
         cdef:
             ServerDataFormat _format
             ClientExchangeFormat xformat
@@ -57,7 +58,8 @@ cdef class ConnectionSettings(pgproto.CodecContext):
                 ))
 
         self._data_codecs.add_python_codec(typeoid, typename, typeschema,
-                                           typekind, encoder, decoder,
+                                           typekind, typeinfos,
+                                           encoder, decoder,
                                            _format, xformat)
 
     cpdef inline remove_python_codec(self, typeoid, typename, typeschema):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1212,28 +1212,11 @@ class TestCodecs(tb.ConnectedTestCase):
             self.assertEqual(at[0].name, 'result')
             self.assertEqual(at[0].type, pt[0])
 
-            err = 'cannot use custom codec on non-scalar type public._hstore'
+            err = 'cannot use custom codec on type public._hstore'
             with self.assertRaisesRegex(asyncpg.InterfaceError, err):
                 await self.con.set_type_codec('_hstore',
                                               encoder=hstore_encoder,
                                               decoder=hstore_decoder)
-
-            await self.con.execute('''
-                CREATE TYPE mytype AS (a int);
-            ''')
-
-            try:
-                err = 'cannot use custom codec on non-scalar type ' + \
-                      'public.mytype'
-                with self.assertRaisesRegex(asyncpg.InterfaceError, err):
-                    await self.con.set_type_codec(
-                        'mytype', encoder=hstore_encoder,
-                        decoder=hstore_decoder)
-            finally:
-                await self.con.execute('''
-                    DROP TYPE mytype;
-                ''')
-
         finally:
             await self.con.execute('''
                 DROP EXTENSION hstore
@@ -1545,6 +1528,53 @@ class TestCodecs(tb.ConnectedTestCase):
                         await self.con.execute('DROP TABLE tab')
         finally:
             await conn.close()
+
+    async def test_custom_codec_composite_tuple(self):
+        await self.con.execute('''
+            CREATE TYPE mycomplex AS (r float, i float);
+        ''')
+
+        try:
+            await self.con.set_type_codec(
+                'mycomplex',
+                encoder=lambda x: (x.real, x.imag),
+                decoder=lambda t: complex(t[0], t[1]),
+                format='tuple',
+            )
+
+            num = complex('1+2j')
+
+            res = await self.con.fetchval(
+                'SELECT $1::mycomplex',
+                num,
+            )
+
+            self.assertEqual(num, res)
+
+        finally:
+            await self.con.execute('''
+                DROP TYPE mycomplex;
+            ''')
+
+    async def test_custom_codec_composite_non_tuple(self):
+        await self.con.execute('''
+            CREATE TYPE mycomplex AS (r float, i float);
+        ''')
+
+        try:
+            with self.assertRaisesRegex(
+                asyncpg.UnsupportedClientFeatureError,
+                "only tuple-format codecs can be used on composite types",
+            ):
+                await self.con.set_type_codec(
+                    'mycomplex',
+                    encoder=lambda x: (x.real, x.imag),
+                    decoder=lambda t: complex(t[0], t[1]),
+                )
+        finally:
+            await self.con.execute('''
+                DROP TYPE mycomplex;
+            ''')
 
     async def test_timetz_encoding(self):
         try:


### PR DESCRIPTION
It is now possible to `set_type_codec('mycomposite', ... format='tuple')`,
which is useful for types that are represented by a composite type in
Postgres, but are an integral type in Python, e.g. `complex`.

Fixes: #1060
