### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402,E731,W503,W504,E252
-exclude = .git,__pycache__,build,dist,.eggs,.github,.local,.venv
+exclude = .git,__pycache__,build,dist,.eggs,.github,.local,.venv,.tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     # job.
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         loop: [asyncio, uvloop]
         exclude:

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.  You can read more about asyncpg in an introductory
 `blog post <http://magic.io/blog/asyncpg-1m-rows-from-postgres-to-python/>`_.
 
-asyncpg requires Python 3.7 or later and is supported for PostgreSQL
+asyncpg requires Python 3.8 or later and is supported for PostgreSQL
 versions 9.5 to 15.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ PostgreSQL and Python/asyncio.  asyncpg is an efficient, clean implementation
 of PostgreSQL server binary protocol for use with Python's ``asyncio``
 framework.
 
-**asyncpg** requires Python 3.7 or later and is supported for PostgreSQL
+**asyncpg** requires Python 3.8 or later and is supported for PostgreSQL
 versions 9.5 to 15.  Older PostgreSQL versions or other databases implementing
 the PostgreSQL protocol *may* work, but are not being actively tested.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "asyncpg"
 description = "An asyncio PostgreSQL driver"
 authors = [{name = "MagicStack Inc", email = "hello@magic.io"}]
-requires-python = '>=3.7.0'
+requires-python = '>=3.8.0'
 readme = "README.rst"
 license = {text = "Apache License, Version 2.0"}
 dynamic = ["version"]
@@ -19,16 +19,12 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database :: Front-Ends",
-]
-dependencies = [
-    'typing-extensions>=3.7.4.3;python_version<"3.8"',
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@
 
 import sys
 
-if sys.version_info < (3, 7):
-    raise RuntimeError('asyncpg requires Python 3.7 or greater')
+if sys.version_info < (3, 8):
+    raise RuntimeError('asyncpg requires Python 3.8 or greater')
 
 import os
 import os.path

--- a/tests/test_adversity.py
+++ b/tests/test_adversity.py
@@ -10,16 +10,14 @@ import asyncio
 import os
 import platform
 import unittest
-import sys
 
 from asyncpg import _testbase as tb
 
 
 @unittest.skipIf(os.environ.get('PGHOST'), 'using remote cluster for testing')
 @unittest.skipIf(
-    platform.system() == 'Windows' and
-    sys.version_info >= (3, 8),
-    'not compatible with ProactorEventLoop which is default in Python 3.8')
+    platform.system() == 'Windows',
+    'not compatible with ProactorEventLoop which is default in Python 3.8+')
 class TestConnectionLoss(tb.ProxiedClusterTestCase):
     @tb.with_timeout(30.0)
     async def test_connection_close_timeout(self):

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -8,7 +8,6 @@
 import asyncio
 import os
 import platform
-import sys
 import unittest
 
 from asyncpg import _testbase as tb
@@ -314,9 +313,8 @@ class TestLogListeners(tb.ConnectedTestCase):
 
 @unittest.skipIf(os.environ.get('PGHOST'), 'using remote cluster for testing')
 @unittest.skipIf(
-    platform.system() == 'Windows' and
-    sys.version_info >= (3, 8),
-    'not compatible with ProactorEventLoop which is default in Python 3.8')
+    platform.system() == 'Windows',
+    'not compatible with ProactorEventLoop which is default in Python 3.8+')
 class TestConnectionTerminationListener(tb.ProxiedClusterTestCase):
 
     async def test_connection_termination_callback_called_on_remote(self):


### PR DESCRIPTION
Since Python 3.7 is EOL, it would be good to drop it from the next release