### PR TITLE
Update automatic PostGIS automatic type conversion example for Shapely 1.8/2.0

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -288,7 +288,7 @@ will work.
                 if not hasattr(geometry, '__geo_interface__'):
                     raise TypeError('{g} does not conform to '
                                     'the geo interface'.format(g=geometry))
-                shape = shapely.geometry.asShape(geometry)
+                shape = shapely.geometry.shape(geometry)
                 return shapely.wkb.dumps(shape)
 
             def decode_geometry(wkb):


### PR DESCRIPTION
Shapely 1.8/2.0 depreciates the `shapely.geometry.asShape()` method in favor of `shapely.geometry.shape()` [source](https://shapely.readthedocs.io/en/stable/migration.html#other-deprecated-functionality).

Small change, but could save someone my headache.