### PR TITLE
Allow Cython 3 (fix #1083)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ requires = [
     "setuptools>=60",
     "wheel",
 
-    "Cython(>=0.29.24,<3.0.0)"
+    "Cython(>=0.29.24,<4.0.0)"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command import sdist as setuptools_sdist
 from setuptools.command import build_ext as setuptools_build_ext
 
 
-CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<0.30.0)'
+CYTHON_DEPENDENCY = 'Cython(>=0.29.24,<4.0.0)'
 
 CFLAGS = ['-O2']
 LDFLAGS = []


### PR DESCRIPTION
This simply loosens the version upper bounds to `<4.0.0`.