### PR TITLE
fix: return the pool from _async_init__ if it's already initialized

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -392,7 +392,7 @@ class Pool:
 
     async def _async__init__(self):
         if self._initialized:
-            return
+            return self
         if self._initializing:
             raise exceptions.InterfaceError(
                 'pool is being initialized in another task')


### PR DESCRIPTION
In situations where the pool is awaited multiple times, `None` is returned after the initial `await`. To fix this, the pool is returned from `_async_init__` when the pool is already initialized and not just after the first initialization.  