### PR TITLE
feat: add `socket_callback` to connect

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -870,7 +870,11 @@ async def __connect_addr(
         # if socket factory callback is given, create socket and use
         # for connection
         sock = await params.socket_callback()
-        connector = loop.create_connection(proto_factory, sock=sock)
+        if params.ssl:
+            host, _ = sock.getpeername()
+            connector = loop.create_connection(proto_factory, sock=sock, ssl=params.ssl, server_hostname=host)
+        else:
+            connector = loop.create_connection(proto_factory, sock=sock)
 
     elif params.ssl:
         connector = _create_ssl_connection(

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -2007,7 +2007,8 @@ async def connect(dsn=None, *,
                   connection_class=Connection,
                   record_class=protocol.Record,
                   server_settings=None,
-                  target_session_attrs=None):
+                  target_session_attrs=None,
+                  socket_callback=None):
     r"""A coroutine to establish a connection to a PostgreSQL server.
 
     The connection parameters may be specified either as a connection
@@ -2344,7 +2345,8 @@ async def connect(dsn=None, *,
             statement_cache_size=statement_cache_size,
             max_cached_statement_lifetime=max_cached_statement_lifetime,
             max_cacheable_statement_size=max_cacheable_statement_size,
-            target_session_attrs=target_session_attrs
+            target_session_attrs=target_session_attrs,
+            socket_callback=socket_callback
         )
 
 


### PR DESCRIPTION
Looking to add a socket factory callback to `connect` in order to allow connections from pre-configured socket like object.

Closes #1054  