### PR TITLE
Allow executemany to return rows

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -538,7 +538,8 @@ class Pool:
         async with self.acquire() as con:
             return await con.execute(query, *args, timeout=timeout)
 
-    async def executemany(self, command: str, args, *, timeout: float=None):
+    async def executemany(self, command: str, args, *, timeout: float=None,
+                          return_rows: bool=False):
         """Execute an SQL *command* for each sequence of arguments in *args*.
 
         Pool performs this operation using one of its connections.  Other than
@@ -549,7 +550,8 @@ class Pool:
         .. versionadded:: 0.10.0
         """
         async with self.acquire() as con:
-            return await con.executemany(command, args, timeout=timeout)
+            return await con.executemany(
+                command, args, timeout=timeout, return_rows=return_rows)
 
     async def fetch(
         self,

--- a/asyncpg/prepared_stmt.py
+++ b/asyncpg/prepared_stmt.py
@@ -211,18 +211,28 @@ class PreparedStatement(connresource.ConnectionResource):
         return data[0]
 
     @connresource.guarded
-    async def executemany(self, args, *, timeout: float=None):
+    async def executemany(self, args, *, timeout: float=None,
+                          return_rows: bool=False):
         """Execute the statement for each sequence of arguments in *args*.
 
         :param args: An iterable containing sequences of arguments.
         :param float timeout: Optional timeout value in seconds.
-        :return None: This method discards the results of the operations.
+        :param bool return_rows:
+            If ``True``, the resulting rows of each command will be
+            returned as a list of :class:`~asyncpg.Record`
+            (defaults to ``False``).
+        :return:
+            None, or a list of :class:`~asyncpg.Record` instances
+            if `return_rows` is true.
 
         .. versionadded:: 0.22.0
+
+        .. versionchanged:: 0.30.0
+            Added `return_rows` keyword-only parameter.
         """
         return await self.__do_execute(
             lambda protocol: protocol.bind_execute_many(
-                self._state, args, '', timeout))
+                self._state, args, '', timeout, return_rows=return_rows))
 
     async def __do_execute(self, executor):
         protocol = self._connection._protocol

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -174,7 +174,7 @@ cdef class CoreProtocol:
     cdef _bind_execute(self, str portal_name, str stmt_name,
                        WriteBuffer bind_data, int32_t limit)
     cdef bint _bind_execute_many(self, str portal_name, str stmt_name,
-                                 object bind_data)
+                                 object bind_data, bint return_rows)
     cdef bint _bind_execute_many_more(self, bint first=*)
     cdef _bind_execute_many_fail(self, object error, bint first=*)
     cdef _bind(self, str portal_name, str stmt_name,

--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -940,12 +940,12 @@ cdef class CoreProtocol:
         self._send_bind_message(portal_name, stmt_name, bind_data, limit)
 
     cdef bint _bind_execute_many(self, str portal_name, str stmt_name,
-                                 object bind_data):
+                                 object bind_data, bint return_rows):
         self._ensure_connected()
         self._set_state(PROTOCOL_BIND_EXECUTE_MANY)
 
-        self.result = None
-        self._discard_data = True
+        self.result = [] if return_rows else None
+        self._discard_data = not return_rows
         self._execute_iter = bind_data
         self._execute_portal_name = portal_name
         self._execute_stmt_name = stmt_name

--- a/asyncpg/protocol/protocol.pyx
+++ b/asyncpg/protocol/protocol.pyx
@@ -213,6 +213,7 @@ cdef class BaseProtocol(CoreProtocol):
         args,
         portal_name: str,
         timeout,
+        return_rows: bool,
     ):
         if self.cancel_waiter is not None:
             await self.cancel_waiter
@@ -238,7 +239,8 @@ cdef class BaseProtocol(CoreProtocol):
             more = self._bind_execute_many(
                 portal_name,
                 state.name,
-                arg_bufs)  # network op
+                arg_bufs,
+                return_rows)  # network op
 
             self.last_query = state.query
             self.statement = state


### PR DESCRIPTION
Fixes https://github.com/MagicStack/asyncpg/issues/448

This is a proposed change to support `executemany` with `INSERT ... RETURNING`. 

The PR adds a flag parameter to `executemany`, but adding a seperate method like `fetchmany` was also mentioned.

@elprans would you consider something along those lines? I think the value here is allowing to take advantage of the query pipelining from `executemany` while avoiding the limitations of the proposed workarounds (like `DEFAULT` as mentioned in your stackoverflow post)