### PR TITLE
Implement SSPI authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,10 +58,17 @@ This enables asyncpg to have easy-to-use support for:
 Installation
 ------------
 
-asyncpg is available on PyPI and has no dependencies.
-Use pip to install::
+asyncpg is available on PyPI.  When not using GSSAPI/SSPI authentication it
+has no dependencies.  Use pip to install::
 
     $ pip install asyncpg
+
+If you need GSSAPI/SSPI authentication, use::
+
+    $ pip install 'asyncpg[gssauth]'
+
+For more details, please `see the documentation
+<https://magicstack.github.io/asyncpg/current/installation.html>`_.
 
 
 Basic Usage

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -2008,7 +2008,8 @@ async def connect(dsn=None, *,
                   record_class=protocol.Record,
                   server_settings=None,
                   target_session_attrs=None,
-                  krbsrvname=None):
+                  krbsrvname=None,
+                  gsslib=None):
     r"""A coroutine to establish a connection to a PostgreSQL server.
 
     The connection parameters may be specified either as a connection
@@ -2240,6 +2241,10 @@ async def connect(dsn=None, *,
         Kerberos service name to use when authenticating with GSSAPI. This
         must match the server configuration. Defaults to 'postgres'.
 
+    :param str gsslib:
+        GSS library to use for GSSAPI/SSPI authentication. Can be 'gssapi'
+        or 'sspi'. Defaults to 'sspi' on Windows and 'gssapi' otherwise.
+
     :return: A :class:`~asyncpg.connection.Connection` instance.
 
     Example:
@@ -2309,7 +2314,7 @@ async def connect(dsn=None, *,
        Added the *target_session_attrs* parameter.
 
     .. versionchanged:: 0.30.0
-       Added the *krbsrvname* parameter.
+       Added the *krbsrvname* and *gsslib* parameters.
 
     .. _SSLContext: https://docs.python.org/3/library/ssl.html#ssl.SSLContext
     .. _create_default_context:
@@ -2354,6 +2359,7 @@ async def connect(dsn=None, *,
             max_cacheable_statement_size=max_cacheable_statement_size,
             target_session_attrs=target_session_attrs,
             krbsrvname=krbsrvname,
+            gsslib=gsslib,
         )
 
 

--- a/asyncpg/protocol/coreproto.pxd
+++ b/asyncpg/protocol/coreproto.pxd
@@ -91,7 +91,7 @@ cdef class CoreProtocol:
         object con_params
         # Instance of SCRAMAuthentication
         SCRAMAuthentication scram
-        # Instance of gssapi.SecurityContext
+        # Instance of gssapi.SecurityContext or sspilib.SecurityContext
         object gss_ctx
 
         readonly int32_t backend_pid
@@ -138,7 +138,9 @@ cdef class CoreProtocol:
     cdef _auth_password_message_md5(self, bytes salt)
     cdef _auth_password_message_sasl_initial(self, list sasl_auth_methods)
     cdef _auth_password_message_sasl_continue(self, bytes server_response)
-    cdef _auth_gss_init(self)
+    cdef _auth_gss_init_gssapi(self)
+    cdef _auth_gss_init_sspi(self, bint negotiate)
+    cdef _auth_gss_get_spn(self)
     cdef _auth_gss_step(self, bytes server_response)
 
     cdef _write(self, buf)

--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -724,7 +724,7 @@ cdef class CoreProtocol:
             import gssapi
         except ModuleNotFoundError:
             raise apg_exc.InterfaceError(
-                'gssapi module not found; please install asyncpg[gssapi] to '
+                'gssapi module not found; please install asyncpg[gssauth] to '
                 'use asyncpg with Kerberos/GSSAPI/SSPI authentication'
             ) from None
 
@@ -736,7 +736,7 @@ cdef class CoreProtocol:
             import sspilib
         except ModuleNotFoundError:
             raise apg_exc.InterfaceError(
-                'sspilib module not found; please install asyncpg[gssapi] to '
+                'sspilib module not found; please install asyncpg[gssauth] to '
                 'use asyncpg with Kerberos/GSSAPI/SSPI authentication'
             ) from None
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,20 +4,35 @@
 Installation
 ============
 
-**asyncpg** has no external dependencies and the recommended way to
-install it is to use **pip**:
+**asyncpg** has no external dependencies when not using GSSAPI/SSPI
+authentication.  The recommended way to install it is to use **pip**:
 
 .. code-block:: bash
 
     $ pip install asyncpg
 
+If you need GSSAPI/SSPI authentication, the recommended way is to use
 
-.. note::
+.. code-block:: bash
 
-   It is recommended to use **pip** version **8.1** or later to take
-   advantage of the precompiled wheel packages.  Older versions of pip
-   will ignore the wheel packages and install asyncpg from the source
-   package.  In that case a working C compiler is required.
+    $ pip install 'asyncpg[gssauth]'
+
+This installs SSPI support on Windows and GSSAPI support on non-Windows
+platforms.  SSPI and GSSAPI interoperate as clients and servers: an SSPI
+client can authenticate to a GSSAPI server and vice versa.
+
+On Linux installing GSSAPI requires a working C compiler and Kerberos 5
+development files.  The latter can be obtained by installing **libkrb5-dev**
+package on Debian/Ubuntu or **krb5-devel** on RHEL/Fedora.  (This is needed
+because PyPI does not have Linux wheels for **gssapi**. See `here for the
+details <https://github.com/pythongssapi/python-gssapi/issues/200#issuecomment-1032934269>`_.)
+
+It is also possible to use GSSAPI on Windows:
+
+  * `pip install gssapi`
+  * Install `Kerberos for Windows <https://web.mit.edu/kerberos/dist/>`_.
+  * Set the ``gsslib`` parameter or the ``PGGSSLIB`` environment variable to
+    `gssapi` when connecting.
 
 
 Building from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 github = "https://github.com/MagicStack/asyncpg"
 
 [project.optional-dependencies]
-gssapi = [
+gssauth = [
     'gssapi; platform_system != "Windows"',
     'sspilib; platform_system == "Windows"',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ github = "https://github.com/MagicStack/asyncpg"
 
 [project.optional-dependencies]
 gssapi = [
-    'gssapi',
+    'gssapi; platform_system != "Windows"',
+    'sspilib; platform_system == "Windows"',
 ]
 test = [
     'flake8~=6.1',
@@ -44,6 +45,7 @@ test = [
     'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.12.0"',
     'gssapi; platform_system == "Linux"',
     'k5test; platform_system == "Linux"',
+    'sspilib; platform_system == "Windows"',
     'mypy~=1.8.0',
 ]
 docs = [


### PR DESCRIPTION
SSPI is a Windows technology for secure authentication. SSPI and GSSAPI interoperate as clients and servers. Postgres documentation recommends using SSPI on Windows clients and servers and GSSAPI on non-Windows platforms[1].

Changes in this PR:

* Support AUTH_REQUIRED_SSPI server request. This is the same as AUTH_REQUIRED_GSS, except it allows negotiation with SSPI clients.

* Allow using SSPI on the client. Which library to use can be specified using the `gsslib` connection parameter.

* Use SSPI instead of GSSAPI on Windows by default. The latter requires installing Kerberos for Windows and is unlikely to work out of the box.

Closes #142

[1] https://www.postgresql.org/docs/current/sspi-auth.html