### PR TITLE
Replace obsolete, unsafe Py_TRASHCAN_SAFE_BEGIN/END

### DIFF
--- a/asyncpg/protocol/record/recordobj.c
+++ b/asyncpg/protocol/record/recordobj.c
@@ -98,7 +98,7 @@ record_dealloc(ApgRecordObject *o)
 
     Py_CLEAR(o->desc);
 
-    Py_TRASHCAN_SAFE_BEGIN(o)
+    Py_TRASHCAN_BEGIN(o, record_dealloc)
     if (len > 0) {
         i = len;
         while (--i >= 0) {
@@ -117,7 +117,7 @@ record_dealloc(ApgRecordObject *o)
     }
     Py_TYPE(o)->tp_free((PyObject *)o);
 done:
-    Py_TRASHCAN_SAFE_END(o)
+    Py_TRASHCAN_END
 }
 
 


### PR DESCRIPTION
Use `Py_TRASHCAN_BEGIN`/`END` instead.

https://bugs.python.org/issue44874

These are removed from the limited C API in Python 3.9, deprecated in 3.11, and removed in Python 3.13:

https://docs.python.org/3.13/whatsnew/3.13.html#id8