### PR TITLE
WIP: Add Testing Failcase for DSN Parsing

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -563,6 +563,26 @@ class TestConnectParams(tb.TestCase):
                 'target_session_attrs': 'any'})
         },
 
+        #postgresql://eoapi:a2Vw%3Ayk=%29CdSis%5Bfek%5DtW=%2Fo@eoapi-primary.default.svc:5432/eoapi
+        {
+            'name': 'dsn_bad_characters_maybe',
+            'env': {
+                'PGUSER': 'eoapi',
+                'PGDATABASE': 'eoapi',
+                'PGPASSWORD': 'a2Vw:yk=)CdSis[fek]tW=/o',
+                'PGHOST': 'eoapi-primary.default.svc',
+                'PGPORT': '5432',
+            },
+
+            'dsn': 'postgres://eoapi:"a2Vw:yk=)CdSis[fek]tW=/o"@eoapi-primary.default.svc:5432/eoapi',
+
+            'result': ([('eoapi-primary.default.svc', 5432)], {
+                'user': 'eoapi',
+                'password': 'a2Vw:yk=)CdSis[fek]tW=/o',
+                'database': 'eoapi',
+                'ssl': True})
+        },
+
         {
             'name': 'params_override_env_and_dsn_ssl_prefer',
             'env': {

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -565,21 +565,15 @@ class TestConnectParams(tb.TestCase):
 
         {
             'name': 'dsn_bad_characters_maybe',
-            'env': {
-                'PGUSER': 'eoapi',
-                'PGDATABASE': 'eoapi',
-                'PGPASSWORD': 'a2Vw:yk=)CdSis[fek]tW=/o',
-                'PGHOST': 'eoapi-primary.default.svc',
-                'PGPORT': '5432',
-            },
-
-            'dsn': 'postgres://eoapi:"a2Vw:yk=)CdSis[fek]tW=/o"@eoapi-primary.default.svc:5432/eoapi',
-
+            'dsn': 'postgres://eoapi:a2Vw%3Ayk%3D%29CdSis%5Bfek%5DtW%3D/o@eoapi-primary.default.svc:5432/eoapi',
             'result': ([('eoapi-primary.default.svc', 5432)], {
                 'user': 'eoapi',
                 'password': 'a2Vw:yk=)CdSis[fek]tW=/o',
                 'database': 'eoapi',
-                'ssl': True})
+                'ssl': True,
+                'sslmode': SSLMode.prefer
+                ,
+                'target_session_attrs': 'any'})
         },
 
         {
@@ -1188,6 +1182,7 @@ class TestConnectParams(tb.TestCase):
 
     def test_connect_params(self):
         for testcase in self.TESTS:
+            print(testcase)
             self.run_testcase(testcase)
 
     def test_connect_pgpass_regular(self):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -565,7 +565,7 @@ class TestConnectParams(tb.TestCase):
 
         {
             'name': 'dsn_bad_characters_maybe',
-            'dsn': 'postgres://eoapi:a2Vw%3Ayk%3D%29CdSis%5Bfek%5DtW%3D/o@eoapi-primary.default.svc:5432/eoapi',
+            'dsn': 'postgres://eoapi:a2Vw%3Ayk%3D%29CdSis%5Bfek%5DtW%3D%2Fo@eoapi-primary.default.svc:5432/eoapi',
             'result': ([('eoapi-primary.default.svc', 5432)], {
                 'user': 'eoapi',
                 'password': 'a2Vw:yk=)CdSis[fek]tW=/o',

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -563,7 +563,6 @@ class TestConnectParams(tb.TestCase):
                 'target_session_attrs': 'any'})
         },
 
-        #postgresql://eoapi:a2Vw%3Ayk=%29CdSis%5Bfek%5DtW=%2Fo@eoapi-primary.default.svc:5432/eoapi
         {
             'name': 'dsn_bad_characters_maybe',
             'env': {


### PR DESCRIPTION
#### Problem

Crunchydata Postgresql Operator creates passwords by default using the `US-ASCII` spec. Some of them with special characters in it including `@`, `[`, `]`, `/` that seem to cause problems for `asyncpg` host parsing even after running `urllib.parse.quote` on the password.

The error below shows it return the password assuming it's the port from an example app:

```bash
  File "/usr/local/lib/python3.8/site-packages/asyncpg/connect_utils.py", line 633, in _parse_connect_arguments
    addrs, params = _parse_connect_dsn_and_args(
  File "/usr/local/lib/python3.8/site-packages/asyncpg/connect_utils.py", line 288, in _parse_connect_dsn_and_args
    host, port = _parse_hostlist(dsn_hostspec, port, unquote=True)
  File "/usr/local/lib/python3.8/site-packages/asyncpg/connect_utils.py", line 229, in _parse_hostlist
    hostlist_ports.append(int(hostspec_port))
ValueError: invalid literal for int() with base 10: 'a2Vw:yk=)CdSis[fek]tW='
```

Test output (from this PR) running locally:

```python
――――――――――――――――――――――――――――――――――――――――――――――――― TestConnectParams.test_connect_params ―――――――――――――――――――――――――――――――――――――――――――――――――
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/unittest/case.py", line 57, in testPartExecutor
    yield
  File "/usr/local/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/usr/local/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/Users/ranchodeluxe/apps/asyncpg/tests/test_connect.py", line 1186, in test_connect_params
    self.run_testcase(testcase)
  File "/Users/ranchodeluxe/apps/asyncpg/tests/test_connect.py", line 1106, in run_testcase
    addrs, params = connect_utils._parse_connect_dsn_and_args(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranchodeluxe/apps/asyncpg/asyncpg/connect_utils.py", line 296, in _parse_connect_dsn_and_args
    host, port = _parse_hostlist(dsn_hostspec, port, unquote=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ranchodeluxe/apps/asyncpg/asyncpg/connect_utils.py", line 231, in _parse_hostlist
    hostlist_ports.append(int(hostspec_port))
                          ^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'a2Vw:yk=)CdSis[fek]tW='
```