### PR TITLE
Don't attempt to canonicalize peer name in Kerberos/GSSAPI/SSPI auth

### DIFF
--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -747,15 +747,12 @@ cdef class CoreProtocol:
 
     cdef _auth_gss_get_spn(self):
         service_name = self.con_params.krbsrvname or 'postgres'
-        # find the canonical name of the server host
         if isinstance(self.address, str):
             raise apg_exc.InternalClientError(
                 'GSSAPI/SSPI authentication is only supported for TCP/IP '
                 'connections')
 
-        host = self.address[0]
-        host_cname = socket.gethostbyname_ex(host)[0]
-        return f'{service_name}/{host_cname}'
+        return f'{service_name}/{self.address[0]}'
 
     cdef _auth_gss_step(self, bytes server_response):
         cdef:


### PR DESCRIPTION
libpq does not canonicalize and neither should we, because:

1) it's likely the wrong thing to do and removes control from the user;
2) it introduces a blocking DNS lookup into an async path, which is not
   great.
