### PR TITLE
Require async_timeout for python < 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Database :: Front-Ends",
 ]
 dependencies = [
-    'async_timeout>=4.0.3; python_version < "3.12.0"',
+    'async_timeout>=4.0.3; python_version < "3.11.0"',
 ]
 
 [project.urls]


### PR DESCRIPTION
Hello,

It looks like `async_timeout` might only be installed for python < 3.11.

This was initially added in #1086 as part of the switch to the updated in python 3.12 `asyncio.wait_for`, however `asyncio.timeout` is available starting from 3.11.