### PR TITLE
handle `None` parameters in query, returning NULL

### DIFF
--- a/asyncpg/utils.py
+++ b/asyncpg/utils.py
@@ -42,4 +42,11 @@ async def _mogrify(conn, query, args):
 
     # Finally, replace $n references with text values.
     return re.sub(
-        r'\$(\d+)\b', lambda m: textified[int(m.group(1)) - 1], query)
+        r"\$(\d+)\b",
+        lambda m: (
+            textified[int(m.group(1)) - 1]
+            if textified[int(m.group(1)) - 1] is not None
+            else "NULL"
+        ),
+        query,
+    )

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -148,12 +148,14 @@ class TestCopyFrom(tb.ConnectedTestCase):
 
         res = await self.con.copy_from_query('''
             SELECT
-                i, i * 10
+                i,
+                i * 10,
+                $2::text
             FROM
                 generate_series(1, 5) AS i
             WHERE
                 i = $1
-        ''', 3, output=f)
+        ''', 3, None, output=f)
 
         self.assertEqual(res, 'COPY 1')
 
@@ -161,7 +163,7 @@ class TestCopyFrom(tb.ConnectedTestCase):
         self.assertEqual(
             output,
             [
-                '3\t30',
+                '3\t30\t\\N',
                 ''
             ]
         )


### PR DESCRIPTION
When a parameter to a query is of `NoneType` it should populate with `NULL` in the query, it was currently leaving an empty space. 