### PR TITLE
Allow testing with uvloop on Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,6 @@ jobs:
           # uvloop does not support windows
           - loop: uvloop
             os: windows-latest
-          # No 3.12 release yet
-          - loop: uvloop
-            python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ gssauth = [
 test = [
     'flake8~=6.1',
     'flake8-pyi~=24.1.0',
-    'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.13.0"',
+    'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.14.0"',
     'gssapi; platform_system == "Linux"',
     'k5test; platform_system == "Linux"',
     'sspilib; platform_system == "Windows"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ gssauth = [
 test = [
     'flake8~=6.1',
     'flake8-pyi~=24.1.0',
-    'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.12.0"',
+    'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.13.0"',
     'gssapi; platform_system == "Linux"',
     'k5test; platform_system == "Linux"',
     'sspilib; platform_system == "Windows"',


### PR DESCRIPTION
There have been binary wheels for uvloop for Python 3.12 for some time.