### PR TITLE
asyncpg v0.30.0

### DIFF
--- a/.github/workflows/install-krb5.sh
+++ b/.github/workflows/install-krb5.sh
@@ -1,10 +1,42 @@
 #!/bin/bash
 
 set -Eexuo pipefail
+shopt -s nullglob
 
-if [ "$RUNNER_OS" == "Linux" ]; then
-    # Assume Ubuntu since this is the only Linux used in CI.
-    sudo apt-get update
-    sudo apt-get install -y --no-install-recommends \
-        libkrb5-dev krb5-user krb5-kdc krb5-admin-server
+if [[ $OSTYPE == linux* ]]; then
+    if [ "$(id -u)" = "0" ]; then
+        SUDO=
+    else
+        SUDO=sudo
+    fi
+
+    if [ -e /etc/os-release ]; then
+        source /etc/os-release
+    elif [ -e /etc/centos-release ]; then
+        ID="centos"
+        VERSION_ID=$(cat /etc/centos-release | cut -f3 -d' ' | cut -f1 -d.)
+    else
+        echo "install-krb5.sh: cannot determine which Linux distro this is" >&2
+        exit 1
+    fi
+
+    if [ "${ID}" = "debian" -o "${ID}" = "ubuntu" ]; then
+        export DEBIAN_FRONTEND=noninteractive
+
+        $SUDO apt-get update
+        $SUDO apt-get install -y --no-install-recommends \
+            libkrb5-dev krb5-user krb5-kdc krb5-admin-server
+    elif [ "${ID}" = "almalinux" ]; then
+        $SUDO dnf install -y krb5-server krb5-workstation krb5-libs krb5-devel
+    elif [ "${ID}" = "centos" ]; then
+        $SUDO yum install -y krb5-server krb5-workstation krb5-libs krb5-devel
+    elif [ "${ID}" = "alpine" ]; then
+        $SUDO apk add krb5 krb5-server krb5-dev
+    else
+        echo "install-krb5.sh: Unsupported linux distro: ${distro}" >&2
+        exit 1
+    fi
+else
+    echo "install-krb5.sh: unsupported OS: ${OSTYPE}" >&2
+    exit 1
 fi

--- a/.github/workflows/install-postgres.sh
+++ b/.github/workflows/install-postgres.sh
@@ -3,51 +3,60 @@
 set -Eexuo pipefail
 shopt -s nullglob
 
-PGVERSION=${PGVERSION:-12}
+if [[ $OSTYPE == linux* ]]; then
+    PGVERSION=${PGVERSION:-12}
 
-if [ -e /etc/os-release ]; then
-    source /etc/os-release
-elif [ -e /etc/centos-release ]; then
-    ID="centos"
-    VERSION_ID=$(cat /etc/centos-release | cut -f3 -d' ' | cut -f1 -d.)
-else
-    echo "install-postgres.sh: cannot determine which Linux distro this is" >&2
-    exit 1
-fi
-
-if [ "${ID}" = "debian" -o "${ID}" = "ubuntu" ]; then
-    export DEBIAN_FRONTEND=noninteractive
-
-    apt-get install -y --no-install-recommends curl gnupg ca-certificates
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-    mkdir -p /etc/apt/sources.list.d/
-    echo "deb https://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" \
-        >> /etc/apt/sources.list.d/pgdg.list
-    apt-get update
-    apt-get install -y --no-install-recommends \
-        "postgresql-${PGVERSION}" \
-        "postgresql-contrib-${PGVERSION}"
-elif [ "${ID}" = "almalinux" ]; then
-    yum install -y \
-        "postgresql-server" \
-        "postgresql-devel" \
-        "postgresql-contrib"
-elif [ "${ID}" = "centos" ]; then
-    el="EL-${VERSION_ID%.*}-$(arch)"
-    baseurl="https://download.postgresql.org/pub/repos/yum/reporpms"
-    yum install -y "${baseurl}/${el}/pgdg-redhat-repo-latest.noarch.rpm"
-    if [ ${VERSION_ID%.*} -ge 8 ]; then
-        dnf -qy module disable postgresql
+    if [ -e /etc/os-release ]; then
+        source /etc/os-release
+    elif [ -e /etc/centos-release ]; then
+        ID="centos"
+        VERSION_ID=$(cat /etc/centos-release | cut -f3 -d' ' | cut -f1 -d.)
+    else
+        echo "install-postgres.sh: cannot determine which Linux distro this is" >&2
+        exit 1
     fi
-    yum install -y \
-        "postgresql${PGVERSION}-server" \
-        "postgresql${PGVERSION}-contrib"
-    ln -s "/usr/pgsql-${PGVERSION}/bin/pg_config" "/usr/local/bin/pg_config"
-elif [ "${ID}" = "alpine" ]; then
-    apk add shadow postgresql postgresql-dev postgresql-contrib
+
+    if [ "${ID}" = "debian" -o "${ID}" = "ubuntu" ]; then
+        export DEBIAN_FRONTEND=noninteractive
+
+        apt-get install -y --no-install-recommends curl gnupg ca-certificates
+        curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+        mkdir -p /etc/apt/sources.list.d/
+        echo "deb https://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" \
+            >> /etc/apt/sources.list.d/pgdg.list
+        apt-get update
+        apt-get install -y --no-install-recommends \
+            "postgresql-${PGVERSION}" \
+            "postgresql-contrib-${PGVERSION}"
+    elif [ "${ID}" = "almalinux" ]; then
+        yum install -y \
+            "postgresql-server" \
+            "postgresql-devel" \
+            "postgresql-contrib"
+    elif [ "${ID}" = "centos" ]; then
+        el="EL-${VERSION_ID%.*}-$(arch)"
+        baseurl="https://download.postgresql.org/pub/repos/yum/reporpms"
+        yum install -y "${baseurl}/${el}/pgdg-redhat-repo-latest.noarch.rpm"
+        if [ ${VERSION_ID%.*} -ge 8 ]; then
+            dnf -qy module disable postgresql
+        fi
+        yum install -y \
+            "postgresql${PGVERSION}-server" \
+            "postgresql${PGVERSION}-contrib"
+        ln -s "/usr/pgsql-${PGVERSION}/bin/pg_config" "/usr/local/bin/pg_config"
+    elif [ "${ID}" = "alpine" ]; then
+        apk add shadow postgresql postgresql-dev postgresql-contrib
+    else
+        echo "install-postgres.sh: unsupported Linux distro: ${distro}" >&2
+        exit 1
+    fi
+
+    useradd -m -s /bin/bash apgtest
+
+elif [[ $OSTYPE == darwin* ]]; then
+    brew install postgresql
+
 else
-    echo "install-postgres.sh: Unsupported distro: ${distro}" >&2
+    echo "install-postgres.sh: unsupported OS: ${OSTYPE}" >&2
     exit 1
 fi
-
-useradd -m -s /bin/bash apgtest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist
-        path: dist/
+        name: dist-version
+        path: dist/VERSION
 
   build-sdist:
     needs: validate-release-request
@@ -67,7 +67,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-sdist
         path: dist/*.tar.*
 
   build-wheels-matrix:
@@ -127,8 +127,18 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-wheels-${{ matrix.only }}
         path: wheelhouse/*.whl
+
+  merge-artifacts:
+    runs-on: ubuntu-latest
+    needs: [build-sdist, build-wheels]
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: dist
+          delete-merged: true
 
   publish-docs:
     needs: [build-sdist, build-wheels]
@@ -180,6 +190,12 @@ jobs:
     needs: [build-sdist, build-wheels, publish-docs]
     runs-on: ubuntu-latest
 
+    environment:
+      name: pypi
+      url: https://pypi.org/p/asyncpg
+    permissions:
+      id-token: write
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -223,7 +239,4 @@ jobs:
     - name: Upload to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
-        # password: ${{ secrets.TEST_PYPI_TOKEN }}
-        # repository_url: https://test.pypi.org/legacy/
+        attestations: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,28 +48,28 @@ jobs:
         missing_version_ok: yes
         version_file: asyncpg/_version.py
         version_line_pattern: |
-          __version__\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
+          __version__(?:\s*:\s*typing\.Final)?\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
     - name: Setup PostgreSQL
-      if: steps.release.outputs.version == 0 && matrix.os == 'macos-latest'
+      if: "!steps.release.outputs.is_release && matrix.os == 'macos-latest'"
       run: |
         brew install postgresql
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python Deps
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       run: |
-        .github/workflows/install-krb5.sh
+        [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
         python -m pip install -U pip setuptools wheel
         python -m pip install -e .[test]
 
     - name: Test
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       env:
         LOOP_IMPL: ${{ matrix.loop }}
       run: |
@@ -103,10 +103,10 @@ jobs:
         missing_version_ok: yes
         version_file: asyncpg/_version.py
         version_line_pattern: |
-          __version__\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
+          __version__(?:\s*:\s*typing\.Final)?\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
     - name: Set up PostgreSQL
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       env:
         PGVERSION: ${{ matrix.postgres-version }}
         DISTRO_NAME: focal
@@ -118,19 +118,19 @@ jobs:
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       with:
         python-version: "3.x"
 
     - name: Install Python Deps
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       run: |
-        .github/workflows/install-krb5.sh
+        [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
         python -m pip install -U pip setuptools wheel
         python -m pip install -e .[test]
 
     - name: Test
-      if: steps.release.outputs.version == 0
+      if: "!steps.release.outputs.is_release"
       env:
         PGVERSION: ${{ matrix.postgres-version }}
       run: |

--- a/asyncpg/_testbase/__init__.py
+++ b/asyncpg/_testbase/__init__.py
@@ -226,13 +226,6 @@ def _init_cluster(ClusterCls, cluster_kwargs, initdb_options=None):
     return cluster
 
 
-def _start_cluster(ClusterCls, cluster_kwargs, server_settings,
-                   initdb_options=None):
-    cluster = _init_cluster(ClusterCls, cluster_kwargs, initdb_options)
-    cluster.start(port='dynamic', server_settings=server_settings)
-    return cluster
-
-
 def _get_initdb_options(initdb_options=None):
     if not initdb_options:
         initdb_options = {}
@@ -256,8 +249,12 @@ def _init_default_cluster(initdb_options=None):
             _default_cluster = pg_cluster.RunningCluster()
         else:
             _default_cluster = _init_cluster(
-                pg_cluster.TempCluster, cluster_kwargs={},
-                initdb_options=_get_initdb_options(initdb_options))
+                pg_cluster.TempCluster,
+                cluster_kwargs={
+                    "data_dir_suffix": ".apgtest",
+                },
+                initdb_options=_get_initdb_options(initdb_options),
+            )
 
     return _default_cluster
 

--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -14,4 +14,4 @@ from __future__ import annotations
 
 import typing
 
-__version__: typing.Final = '0.30.0.dev0'
+__version__: typing.Final = '0.30.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ gssauth = [
 test = [
     'flake8~=6.1',
     'flake8-pyi~=24.1.0',
+    'distro~=1.9.0',
     'uvloop>=0.15.3; platform_system != "Windows" and python_version < "3.14.0"',
     'gssapi; platform_system == "Linux"',
     'k5test; platform_system == "Linux"',
@@ -75,13 +76,17 @@ build-frontend = "build"
 test-extras = "test"
 
 [tool.cibuildwheel.macos]
+before-all = ".github/workflows/install-postgres.sh"
 test-command = "python {project}/tests/__init__.py"
 
 [tool.cibuildwheel.windows]
 test-command = "python {project}\\tests\\__init__.py"
 
 [tool.cibuildwheel.linux]
-before-all = ".github/workflows/install-postgres.sh"
+before-all = """
+    .github/workflows/install-postgres.sh \
+    && .github/workflows/install-krb5.sh \
+    """
 test-command = """\
     PY=`which python` \
     && chmod -R go+rX "$(dirname $(dirname $(dirname $PY)))" \


### PR DESCRIPTION
Support Python 3.13 and PostgreSQL 17.

Improvements
============

* Implement GSSAPI authentication
  (by @eltoder in 1d4e5680 for #1122)

* Implement SSPI authentication
  (by @eltoder in 1aab2094 for #1128)

* Add initial typings
  (by @bryanforbes in d42432bf for #1127)

* Allow building with Cython 3
  (by @musicinmybrain in 258d8a95 for #1101)

* docs: fix connection pool close call (#1125)
  (by @paulovitorweb in e8488149 for #1125)

* Add support for the `sslnegotiation` parameter
  (by @elprans in afdb05c7 for #1187)

* Test and build on Python 3.13
  (by @elprans in 3aa98944 for #1188)

* Support PostgreSQL 17
  (by @elprans in cee97e1a for #1189)
  (by @MeggyCal in aa2d0e69 for #1185)

* Add `fetchmany` to execute many *and* return rows
  (by @rossmacarthur in 73f2209d for #1175)

* Add `connect` kwarg to Pool to better support GCP's CloudSQL
  (by @d1manson in 3ee19baa for #1170)

* Allow customizing connection state reset (#1191)
  (by @elprans in f6ec755c for #1191)

Fixes
=====

* s/quote/quote_plus/ in the note about DSN part quoting
  (by @elprans in 1194a8a6 for #1151)

* Use asyncio.run() instead of run_until_complete()
  (by @eltoder in 9fcddfc1 for #1140)

* Require async_timeout for python < 3.11 (#1177)
  (by @Pliner in 327f2a7a for #1177)

* Allow testing with uvloop on Python 3.12 (#1182)
  (by @musicinmybrain in 597fe541 for #1182)

* Mark pool-wrapped connection coroutine methods as coroutines
  (by @elprans in 636420b1 for #1134)

* handle `None` parameters in `copy_from_query`, returning `NULL`
  (by @fobispotc in 259d16e5 for #1180)

* fix: return the pool from _async_init__ if it's already initialized (#1104)
  (by @guacs in 7dc58728 for #1104)

* Replace obsolete, unsafe `Py_TRASHCAN_SAFE_BEGIN/END` (#1150)
  (by @musicinmybrain in 11101c6e for #1150)
