### PR TITLE
asyncpg v0.30.0

### DIFF
--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -14,4 +14,4 @@ from __future__ import annotations
 
 import typing
 
-__version__: typing.Final = '0.30.0.dev0'
+__version__: typing.Final = '0.30.0'


### PR DESCRIPTION
Support Python 3.13 and PostgreSQL 17.

Improvements
============

* Implement GSSAPI authentication
  (by @eltoder in 1d4e5680 for #1122)

* Implement SSPI authentication
  (by @eltoder in 1aab2094 for #1128)

* Add initial typings
  (by @bryanforbes in d42432bf for #1127)

* Allow building with Cython 3
  (by @musicinmybrain in 258d8a95 for #1101)

* docs: fix connection pool close call (#1125)
  (by @paulovitorweb in e8488149 for #1125)

* Add support for the `sslnegotiation` parameter
  (by @elprans in afdb05c7 for #1187)

* Test and build on Python 3.13
  (by @elprans in 3aa98944 for #1188)

* Support PostgreSQL 17
  (by @elprans in cee97e1a for #1189)
  (by @MeggyCal in aa2d0e69 for #1185)

* Add `fetchmany` to execute many *and* return rows
  (by @rossmacarthur in 73f2209d for #1175)

* Add `connect` kwarg to Pool to better support GCP's CloudSQL
  (by @d1manson in 3ee19baa for #1170)

* Allow customizing connection state reset (#1191)
  (by @elprans in f6ec755c for #1191)

Fixes
=====

* s/quote/quote_plus/ in the note about DSN part quoting
  (by @elprans in 1194a8a6 for #1151)

* Use asyncio.run() instead of run_until_complete()
  (by @eltoder in 9fcddfc1 for #1140)

* Require async_timeout for python < 3.11 (#1177)
  (by @Pliner in 327f2a7a for #1177)

* Allow testing with uvloop on Python 3.12 (#1182)
  (by @musicinmybrain in 597fe541 for #1182)

* Mark pool-wrapped connection coroutine methods as coroutines
  (by @elprans in 636420b1 for #1134)

* handle `None` parameters in `copy_from_query`, returning `NULL`
  (by @fobispotc in 259d16e5 for #1180)

* fix: return the pool from _async_init__ if it's already initialized (#1104)
  (by @guacs in 7dc58728 for #1104)

* Replace obsolete, unsafe `Py_TRASHCAN_SAFE_BEGIN/END` (#1150)
  (by @musicinmybrain in 11101c6e for #1150)
