### PR TITLE
Add typing to auxiliary classes around `Pool`

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -34,7 +34,7 @@ class PoolConnectionProxyMeta(type):
         dct: dict[str, Any],
         *,
         wrap: bool = False,
-    ) -> "PoolConnectionProxyMeta":
+    ) -> PoolConnectionProxyMeta:
         if wrap:
             for attrname in dir(connection.Connection):
                 if attrname.startswith('_') or attrname in dct:
@@ -82,7 +82,7 @@ class PoolConnectionProxy(connection._ConnectionProxy,
     __slots__ = ('_con', '_holder')
 
     def __init__(
-        self, holder: "PoolConnectionHolder", con: connection.Connection
+        self, holder: PoolConnectionHolder, con: connection.Connection
     ) -> None:
         self._con = con
         self._holder = holder


### PR DESCRIPTION
In an effort to add more type annotations to common interfaces I decided to tackle some of the simpler methods. Also, to familiarise myself with the CI and project.

There is nothing groundbreaking in this PR. It:
- Adds `-> None` for functions that are not returning anything
- Expands one `__aexit__` to be the correct full type
- Types the arguments and attributes of `PoolConnectionHolder`, `PoolConnectionProxyMeta` and `PoolAcquireContext` based on actual usage patterns.

Let me know if there are any questions. I didn't really see any style checking recommendations in the documentation or `setup.py` so just used what `black`, `ruff` and others have decided is the de facto style of "modern" Python code.