### PR TITLE
Add typing to two objects in `connection_utils`

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -4,6 +4,7 @@
 # This module is part of asyncpg and is released under
 # the Apache 2.0 License: http://www.apache.org/licenses/LICENSE-2.0
 
+from __future__ import annotations
 
 import asyncio
 import collections
@@ -813,7 +814,7 @@ async def _create_ssl_connection(
     # TODO: The return type is a specific combination of subclasses of
     # asyncio.protocols.Protocol that we can't express. For now, having the
     # return type be dependent on signature of the factory is an improvement
-    protocol_factory: "Callable[[], _ProctolFactoryR]",
+    protocol_factory: Callable[[], _ProctolFactoryR],
     host: str,
     port: int,
     *,

--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -764,14 +764,21 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
 
 
 class TLSUpgradeProto(asyncio.Protocol):
-    def __init__(self, loop, host, port, ssl_context, ssl_is_advisory):
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        host: str,
+        port: int,
+        ssl_context: ssl_module.SSLContext,
+        ssl_is_advisory: bool,
+    ) -> None:
         self.on_data = _create_future(loop)
         self.host = host
         self.port = port
         self.ssl_context = ssl_context
         self.ssl_is_advisory = ssl_is_advisory
 
-    def data_received(self, data):
+    def data_received(self, data: bytes) -> None:
         if data == b'S':
             self.on_data.set_result(True)
         elif (self.ssl_is_advisory and
@@ -789,7 +796,7 @@ class TLSUpgradeProto(asyncio.Protocol):
                     'rejected SSL upgrade'.format(
                         host=self.host, port=self.port)))
 
-    def connection_lost(self, exc):
+    def connection_lost(self, exc: typing.Optional[Exception]) -> None:
         if not self.on_data.done():
             if exc is None:
                 exc = ConnectionError('unexpected connection_lost() call')


### PR DESCRIPTION
I noticed that it would be very useful to have a fully typed `connection_utils` as it is the core for a lot of other modules that interact with the `connect.Connection`.

This just adds some basic parameter annotation that is pretty straightforward. I have also decided to be pragmatic and add a `TODO` for stuff that is just too hard right now. We can always revisit cases like this if we ever do want to enable a type checker. In the meantime, having callers of the internal function `_create_ssl_connection` get the correct type already helps with typing the public API correctly. 