### PR TITLE
Add typing to `Pool.acquire`

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
 import functools
 import inspect
 import logging
@@ -405,7 +405,7 @@ class Pool:
         self._holders = []
         self._initialized = False
         self._initializing = False
-        self._queue = None
+        self._queue: Optional[asyncio.LifoQueue[PoolConnectionHolder]] = None
 
         self._connection_class = connection_class
         self._record_class = record_class
@@ -838,7 +838,11 @@ class Pool:
                 where=where
             )
 
-    def acquire(self, *, timeout=None):
+    def acquire(
+        self,
+        *,
+        timeout: Optional[float] = None,
+    ) -> PoolAcquireContext:
         """Acquire a database connection from the pool.
 
         :param float timeout: A timeout for acquiring a Connection.
@@ -863,11 +867,12 @@ class Pool:
         """
         return PoolAcquireContext(self, timeout)
 
-    async def _acquire(self, timeout):
-        async def _acquire_impl():
-            ch = await self._queue.get()  # type: PoolConnectionHolder
+    async def _acquire(self, timeout: Optional[float]) -> PoolConnectionProxy:
+        async def _acquire_impl() -> PoolConnectionProxy:
+            assert self._queue is not None
+            ch = await self._queue.get()
             try:
-                proxy = await ch.acquire()  # type: PoolConnectionProxy
+                proxy = await ch.acquire()
             except (Exception, asyncio.CancelledError):
                 self._queue.put_nowait(ch)
                 raise
@@ -1039,7 +1044,7 @@ class PoolAcquireContext:
         self.connection = None
         self.done = False
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> PoolConnectionProxy:
         if self.connection is not None or self.done:
             raise exceptions.InterfaceError('a connection is already acquired')
         self.connection = await self.pool._acquire(self.timeout)
@@ -1056,7 +1061,7 @@ class PoolAcquireContext:
         self.connection = None
         await self.pool.release(con)
 
-    def __await__(self):
+    def __await__(self) -> Iterator[PoolConnectionProxy]:
         self.done = True
         return self.pool._acquire(self.timeout).__await__()
 


### PR DESCRIPTION
Now that https://github.com/MagicStack/asyncpg/pull/1197 landed I could take the patch I suggested in https://github.com/MagicStack/asyncpg/pull/578 and add some more minor changes.

Therefore, this closes https://github.com/MagicStack/asyncpg/pull/578 and closes https://github.com/MagicStack/asyncpg/pull/521

In the long run, this will probably cause issues. `Proxies` can't really be expressed that well on the type level, so we will probably get a lot of "Unknown attribute" errors on everything that is using whatever comes out of `acquire()`.
However, I would personally advise not to worry about this too much. Let's first add typing to those places where we know it will work in incremental steps and consider larger issues when we have some more experience with adding the types.

We'll likely also run into issues identified in https://github.com/MagicStack/asyncpg/pull/577 but as long as we don't add any typing that is incorrect this can still be solved.

There is (obviously) one behaviour change with the assert, but as I read the code (and tests) I don't think that should be an actual change in behaviour.