### PR TITLE
Fix broken test running documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,14 +51,14 @@ in the root of the source checkout:
 
 .. code-block:: bash
 
-    $ pip install -e .
+    $ make
 
 A debug build containing more runtime checks can be created by setting
 the ``ASYNCPG_DEBUG`` environment variable when building:
 
 .. code-block:: bash
 
-    $ env ASYNCPG_DEBUG=1 pip install -e .
+    $ make debug
 
 
 Running tests
@@ -71,4 +71,4 @@ To execute the testsuite run:
 
 .. code-block:: bash
 
-    $ python setup.py test
+    $ make test


### PR DESCRIPTION
# Background
The [documented steps to run tests](https://magicstack.github.io/asyncpg/current/installation.html#running-tests) say to

```
python setup.py test
```

However, that results in

```
$ python setup.py test
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'test'
```

However, the `make test` target works.

# Changes
1. Reference `make test` for running tests
2. For consistency, also updated build and build debug commands in `Building from source` to use `make` and `make debug`.

# Testing

Ran `make htmldocs` and verified output was correct. Only minor weirdness was the green syntax highlighting on `test` in `make test` (perhaps because it's a built in `bash` command).

## Screenshot of rendered HTML:

![Screenshot 2024-12-14 at 11 39 45](https://github.com/user-attachments/assets/9642903f-daf3-4138-8440-00f4c8c142bd)

