### PR TITLE
Fix multi port connection string issue

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -168,13 +168,15 @@ def _read_password_from_pgpass(
 
 
 def _validate_port_spec(hosts, port):
-    if isinstance(port, list):
+    if isinstance(port, list) and len(port) > 1:
         # If there is a list of ports, its length must
         # match that of the host list.
         if len(port) != len(hosts):
             raise exceptions.ClientConfigurationError(
                 'could not match {} port numbers to {} hosts'.format(
                     len(port), len(hosts)))
+    elif isinstance(port, list) and len(port) == 1:
+        port = [port[0] for _ in range(len(hosts))]
     else:
         port = [port for _ in range(len(hosts))]
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1087,6 +1087,20 @@ class TestConnectParams(tb.TestCase):
                 }
             )
         },
+        {
+            'name': 'multi_host_single_port',
+            'dsn': 'postgres:///postgres?host=127.0.0.1,127.0.0.2&port=5432&user=postgres',
+            'result': (
+                [
+                    ('127.0.0.1', 5432),
+                    ('127.0.0.2', 5432)
+                ], {
+                    'user': 'postgres',
+                    'database': 'postgres',
+                    'target_session_attrs': 'any',
+                }
+            )
+        },
     ]
 
     @contextlib.contextmanager


### PR DESCRIPTION
Currently when using multiple hosts asyncpg requires there be one port per host. Per the postgres [documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-MULTIPLE-HOSTS). "As an exception, if only one port is specified, it applies to all the hosts.".

This PR attempts to fix this inconsistency between libpq and asyncpg.