### PR TITLE
Implement connection service file functionality

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import configparser
 import collections
 from collections.abc import Callable
 import enum
@@ -85,6 +86,9 @@ if _system == 'Windows':
     PGPASSFILE = 'pgpass.conf'
 else:
     PGPASSFILE = '.pgpass'
+
+
+PG_SERVICEFILE = '.pg_service.conf'
 
 
 def _read_password_file(passfile: pathlib.Path) \
@@ -268,7 +272,7 @@ def _dot_postgresql_path(filename) -> typing.Optional[pathlib.Path]:
 
 
 def _parse_connect_dsn_and_args(*, dsn, host, port, user,
-                                password, passfile, database, ssl,
+                                password, passfile, database, ssl, service,
                                 direct_tls, server_settings,
                                 target_session_attrs, krbsrvname, gsslib):
     # `auth_hosts` is the version of host information for the purposes
@@ -277,6 +281,120 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
     sslcert = sslkey = sslrootcert = sslcrl = sslpassword = None
     ssl_min_protocol_version = ssl_max_protocol_version = None
     sslnegotiation = None
+
+    if dsn:
+        parsed = urllib.parse.urlparse(dsn)
+        if parsed.query:
+            query = urllib.parse.parse_qs(parsed.query, strict_parsing=True)
+            for key, val in query.items():
+                if isinstance(val, list):
+                    query[key] = val[-1]
+
+            if 'service' in query:
+                val = query.pop('service')
+                if not service and val:
+                    service = val
+
+        connection_service_file = os.getenv('PGSERVICEFILE')
+        if connection_service_file is None:
+            homedir = compat.get_pg_home_directory()
+            if homedir:
+                connection_service_file = homedir / PG_SERVICEFILE
+            else:
+                connection_service_file = None
+        else:
+          connection_service_file = pathlib.Path(connection_service_file)
+
+        if connection_service_file is not None and service is not None:
+            # TODO Open and parse connection service file
+            pg_service = configparser.ConfigParser()
+            pg_service.read(connection_service_file)
+            if service in pg_service.sections():
+              service_params = pg_service[service]
+              if 'port' in service_params:
+                  val = service_params.pop('port')
+                  if not port and val:
+                      port = [int(p) for p in val.split(',')]
+
+              if 'host' in service_params:
+                  val = service_params.pop('host')
+                  if not host and val:
+                      host, port = _parse_hostlist(val, port)
+
+              if 'dbname' in service_params:
+                  val = service_params.pop('dbname')
+                  if database is None:
+                      database = val
+
+              if 'database' in service_params:
+                  val = service_params.pop('database')
+                  if database is None:
+                      database = val
+
+              if 'user' in service_params:
+                  val = service_params.pop('user')
+                  if user is None:
+                      user = val
+
+              if 'password' in service_params:
+                  val = service_params.pop('password')
+                  if password is None:
+                      password = val
+
+              if 'passfile' in service_params:
+                  val = service_params.pop('passfile')
+                  if passfile is None:
+                      passfile = val
+
+              if 'sslmode' in service_params:
+                  val = service_params.pop('sslmode')
+                  if ssl is None:
+                      ssl = val
+
+              if 'sslcert' in service_params:
+                  sslcert = service_params.pop('sslcert')
+
+              if 'sslkey' in service_params:
+                  sslkey = service_params.pop('sslkey')
+
+              if 'sslrootcert' in service_params:
+                  sslrootcert = service_params.pop('sslrootcert')
+
+              if 'sslnegotiation' in service_params:
+                  sslnegotiation = service_params.pop('sslnegotiation')
+
+              if 'sslcrl' in service_params:
+                  sslcrl = service_params.pop('sslcrl')
+
+              if 'sslpassword' in service_params:
+                  sslpassword = service_params.pop('sslpassword')
+
+              if 'ssl_min_protocol_version' in service_params:
+                  ssl_min_protocol_version = service_params.pop(
+                      'ssl_min_protocol_version'
+                  )
+
+              if 'ssl_max_protocol_version' in service_params:
+                  ssl_max_protocol_version = service_params.pop(
+                      'ssl_max_protocol_version'
+                  )
+
+              if 'target_session_attrs' in service_params:
+                  dsn_target_session_attrs = service_params.pop(
+                      'target_session_attrs'
+                  )
+                  if target_session_attrs is None:
+                      target_session_attrs = dsn_target_session_attrs
+
+              if 'krbsrvname' in service_params:
+                  val = service_params.pop('krbsrvname')
+                  if krbsrvname is None:
+                      krbsrvname = val
+
+              if 'gsslib' in service_params:
+                  val = service_params.pop('gsslib')
+                  if gsslib is None:
+                      gsslib = val
 
     if dsn:
         parsed = urllib.parse.urlparse(dsn)
@@ -406,6 +524,9 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 if gsslib is None:
                     gsslib = val
 
+            if 'service' in query:
+                val = query.pop('service')
+
             if query:
                 if server_settings is None:
                     server_settings = query
@@ -490,6 +611,7 @@ def _parse_connect_dsn_and_args(*, dsn, host, port, user,
                 hosts=auth_hosts, ports=port,
                 database=database, user=user,
                 passfile=passfile)
+
 
     addrs = []
     have_tcp_addrs = False
@@ -724,7 +846,7 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
                              max_cached_statement_lifetime,
                              max_cacheable_statement_size,
                              ssl, direct_tls, server_settings,
-                             target_session_attrs, krbsrvname, gsslib):
+                             target_session_attrs, krbsrvname, gsslib, service):
     local_vars = locals()
     for var_name in {'max_cacheable_statement_size',
                      'max_cached_statement_lifetime',
@@ -754,7 +876,7 @@ def _parse_connect_arguments(*, dsn, host, port, user, password, passfile,
         direct_tls=direct_tls, database=database,
         server_settings=server_settings,
         target_session_attrs=target_session_attrs,
-        krbsrvname=krbsrvname, gsslib=gsslib)
+        krbsrvname=krbsrvname, gsslib=gsslib, service=service)
 
     config = _ClientConfiguration(
         command_timeout=command_timeout,

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -2074,6 +2074,7 @@ class Connection(metaclass=ConnectionMeta):
 async def connect(dsn=None, *,
                   host=None, port=None,
                   user=None, password=None, passfile=None,
+                  service=None,
                   database=None,
                   loop=None,
                   timeout=60,
@@ -2182,6 +2183,10 @@ async def connect(dsn=None, *,
         The name of the file used to store passwords
         (defaults to ``~/.pgpass``, or ``%APPDATA%\postgresql\pgpass.conf``
         on Windows).
+
+    :param service:
+        The name of the postgres connection service stored in the postgres
+        connection service file.
 
     :param loop:
         An asyncio event loop instance.  If ``None``, the default
@@ -2428,6 +2433,7 @@ async def connect(dsn=None, *,
             user=user,
             password=password,
             passfile=passfile,
+            service=service,
             ssl=ssl,
             direct_tls=direct_tls,
             database=database,


### PR DESCRIPTION
This PR attempts to implement connection service file functionality into asyncpg. 

Connection service files are a libpq feature that allows details of postgres connection strings to be stored in a file that is referenced via a `service` parameter in the connection string. This makes it very easy to ensure/enforce consistent connection strings across a codebase. 

https://www.postgresql.org/docs/17/libpq-pgservice.html