### PR TITLE
Fix "implicit optional", e.g. `arg: int = None`

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -311,7 +311,7 @@ class Connection(metaclass=ConnectionMeta):
         """
         return self._protocol.is_in_transaction()
 
-    async def execute(self, query: str, *args, timeout: float=None) -> str:
+    async def execute(self, query: str, *args, timeout: typing.Optional[float]=None) -> str:
         """Execute an SQL command (or commands).
 
         This method can execute many SQL commands at once, when no arguments
@@ -358,7 +358,7 @@ class Connection(metaclass=ConnectionMeta):
         )
         return status.decode()
 
-    async def executemany(self, command: str, args, *, timeout: float=None):
+    async def executemany(self, command: str, args, *, timeout: typing.Optional[float]=None):
         """Execute an SQL *command* for each sequence of arguments in *args*.
 
         Example:
@@ -757,7 +757,7 @@ class Connection(metaclass=ConnectionMeta):
         return data[0]
 
     async def fetchmany(
-        self, query, args, *, timeout: float=None, record_class=None
+        self, query, args, *, timeout: typing.Optional[float]=None, record_class=None
     ):
         """Run a query for each sequence of arguments in *args*
         and return the results as a list of :class:`Record`.

--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -311,7 +311,12 @@ class Connection(metaclass=ConnectionMeta):
         """
         return self._protocol.is_in_transaction()
 
-    async def execute(self, query: str, *args, timeout: typing.Optional[float]=None) -> str:
+    async def execute(
+        self,
+        query: str,
+        *args,
+        timeout: typing.Optional[float]=None,
+    ) -> str:
         """Execute an SQL command (or commands).
 
         This method can execute many SQL commands at once, when no arguments
@@ -358,7 +363,13 @@ class Connection(metaclass=ConnectionMeta):
         )
         return status.decode()
 
-    async def executemany(self, command: str, args, *, timeout: typing.Optional[float]=None):
+    async def executemany(
+        self,
+        command: str,
+        args,
+        *,
+        timeout: typing.Optional[float]=None,
+    ):
         """Execute an SQL *command* for each sequence of arguments in *args*.
 
         Example:
@@ -757,7 +768,12 @@ class Connection(metaclass=ConnectionMeta):
         return data[0]
 
     async def fetchmany(
-        self, query, args, *, timeout: typing.Optional[float]=None, record_class=None
+        self,
+        query,
+        args,
+        *,
+        timeout: typing.Optional[float]=None,
+        record_class=None,
     ):
         """Run a query for each sequence of arguments in *args*
         and return the results as a list of :class:`Record`.

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -574,7 +574,12 @@ class Pool:
 
         return con
 
-    async def execute(self, query: str, *args, timeout: Optional[float]=None) -> str:
+    async def execute(
+        self,
+        query: str,
+        *args,
+        timeout: Optional[float]=None,
+    ) -> str:
         """Execute an SQL command (or commands).
 
         Pool performs this operation using one of its connections.  Other than
@@ -586,7 +591,13 @@ class Pool:
         async with self.acquire() as con:
             return await con.execute(query, *args, timeout=timeout)
 
-    async def executemany(self, command: str, args, *, timeout: Optional[float]=None):
+    async def executemany(
+        self,
+        command: str,
+        args,
+        *,
+        timeout: Optional[float]=None,
+    ):
         """Execute an SQL *command* for each sequence of arguments in *args*.
 
         Pool performs this operation using one of its connections.  Other than

--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -574,7 +574,7 @@ class Pool:
 
         return con
 
-    async def execute(self, query: str, *args, timeout: float=None) -> str:
+    async def execute(self, query: str, *args, timeout: Optional[float]=None) -> str:
         """Execute an SQL command (or commands).
 
         Pool performs this operation using one of its connections.  Other than
@@ -586,7 +586,7 @@ class Pool:
         async with self.acquire() as con:
             return await con.execute(query, *args, timeout=timeout)
 
-    async def executemany(self, command: str, args, *, timeout: float=None):
+    async def executemany(self, command: str, args, *, timeout: Optional[float]=None):
         """Execute an SQL *command* for each sequence of arguments in *args*.
 
         Pool performs this operation using one of its connections.  Other than

--- a/asyncpg/prepared_stmt.py
+++ b/asyncpg/prepared_stmt.py
@@ -6,6 +6,7 @@
 
 
 import json
+import typing
 
 from . import connresource
 from . import cursor
@@ -232,7 +233,7 @@ class PreparedStatement(connresource.ConnectionResource):
         )
 
     @connresource.guarded
-    async def executemany(self, args, *, timeout: float=None):
+    async def executemany(self, args, *, timeout: typing.Optional[float]=None):
         """Execute the statement for each sequence of arguments in *args*.
 
         :param args: An iterable containing sequences of arguments.


### PR DESCRIPTION
The latest version of Pyright makes calling a function with an "implicit optional" a type error. An "implicit optional" is like  the following code, where a parameter is annotated with a type that doesn't include `None` but the default value is `None`:

```python
def foo(arg: int = None):
    pass
```

More info here: https://docs.astral.sh/ruff/rules/implicit-optional/

This PR adds `typing.Optional` where necessary.