### PR TITLE
Disable connection URI tests broken by a recent Python fix

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -846,25 +846,26 @@ class TestConnectParams(tb.TestCase):
             ),
         },
 
-        {
-            'name': 'dsn_ipv6_multi_host',
-            'dsn': 'postgresql://user@[2001:db8::1234%25eth0],[::1]/db',
-            'result': ([('2001:db8::1234%eth0', 5432), ('::1', 5432)], {
-                'database': 'db',
-                'user': 'user',
-                'target_session_attrs': 'any',
-            })
-        },
+        # broken by https://github.com/python/cpython/pull/129418
+        # {
+        #     'name': 'dsn_ipv6_multi_host',
+        #     'dsn': 'postgresql://user@[2001:db8::1234%25eth0],[::1]/db',
+        #     'result': ([('2001:db8::1234%eth0', 5432), ('::1', 5432)], {
+        #         'database': 'db',
+        #         'user': 'user',
+        #         'target_session_attrs': 'any',
+        #     })
+        # },
 
-        {
-            'name': 'dsn_ipv6_multi_host_port',
-            'dsn': 'postgresql://user@[2001:db8::1234]:1111,[::1]:2222/db',
-            'result': ([('2001:db8::1234', 1111), ('::1', 2222)], {
-                'database': 'db',
-                'user': 'user',
-                'target_session_attrs': 'any',
-            })
-        },
+        # {
+        #     'name': 'dsn_ipv6_multi_host_port',
+        #     'dsn': 'postgresql://user@[2001:db8::1234]:1111,[::1]:2222/db',
+        #     'result': ([('2001:db8::1234', 1111), ('::1', 2222)], {
+        #         'database': 'db',
+        #         'user': 'user',
+        #         'target_session_attrs': 'any',
+        #     })
+        # },
 
         {
             'name': 'dsn_ipv6_multi_host_query_part',


### PR DESCRIPTION
A fix for python/cpython#105704 broke parsing of URIs containing
multiple hosts if one or all of the hosts are IPv6 address literals.
This blocks CI, so disable those tests for now until this is fixed
properly.
