### PR TITLE
Make `prepare()` not use named statements by default when cache is disabled

### DIFF
--- a/asyncpg/connection.py
+++ b/asyncpg/connection.py
@@ -394,7 +394,7 @@ class Connection(metaclass=ConnectionMeta):
         query,
         timeout,
         *,
-        named=False,
+        named: typing.Union[str, bool, None] = False,
         use_cache=True,
         ignore_custom_codec=False,
         record_class=None
@@ -628,7 +628,6 @@ class Connection(metaclass=ConnectionMeta):
             query,
             name=name,
             timeout=timeout,
-            use_cache=False,
             record_class=record_class,
         )
 
@@ -636,16 +635,18 @@ class Connection(metaclass=ConnectionMeta):
         self,
         query,
         *,
-        name=None,
+        name: typing.Union[str, bool, None] = None,
         timeout=None,
         use_cache: bool=False,
         record_class=None
     ):
         self._check_open()
+        if name is None:
+            name = self._stmt_cache_enabled
         stmt = await self._get_statement(
             query,
             timeout,
-            named=True if name is None else name,
+            named=name,
             use_cache=use_cache,
             record_class=record_class,
         )
@@ -1099,7 +1100,7 @@ class Connection(metaclass=ConnectionMeta):
         intro_query = 'SELECT {cols} FROM {tab} LIMIT 1'.format(
             tab=tabname, cols=col_list)
 
-        intro_ps = await self._prepare(intro_query, use_cache=True)
+        intro_ps = await self.prepare(intro_query)
 
         cond = self._format_copy_where(where)
         opts = '(FORMAT binary)'


### PR DESCRIPTION
We allow disabling the statement cache to circumvent a proxy's inability to
cope with them, however there are still some holes where the use of a named
statement is attempted: `prepare()` with the default arguments, and
`copy_in()`.  Fix both so that the use of a named statement is dependent
upon whether the prepared statement cache is enabled.

Fixes: #1219
Closes: #1218
