### PR TITLE
asyncpg v0.31.0

### DIFF
--- a/asyncpg/_version.py
+++ b/asyncpg/_version.py
@@ -14,4 +14,4 @@ from __future__ import annotations
 
 import typing
 
-__version__: typing.Final = '0.31.0.dev0'
+__version__: typing.Final = '0.31.0'


### PR DESCRIPTION
Enable Python 3.14 with experimental subinterpreter/freethreading
support.

Improvements
============

* Add Python 3.14 support, experimental subinterpreter/freethreading support (#1279)
  (by @elprans in 9e42642b)

* Avoid performing type introspection on known types (#1243)
  (by @elprans in 5c9986c4)

* Make `prepare()` not use named statements by default when cache is disabled (#1245)
  (by @elprans in 5b14653e)

* Implement connection service file functionality (#1223)
  (by @AndrewJackson2020 in 1d63bb15)

Fixes
=====

* Fix multi port connection string issue (#1222)
  (by @AndrewJackson2020 in 01c0db7b)

* Avoid leaking connections if _can_use_connection fails (#1269)
  (by @yuliy-openai in e94302d2)

Other
=====

* Drop support for EOL Python 3.8 (#1281)
  (by @elprans in 6c2c4904)
