### PR TITLE
Avoids wrapping client_encoding with additional single-quotes

### DIFF
--- a/asyncpg/protocol/coreproto.pyx
+++ b/asyncpg/protocol/coreproto.pyx
@@ -941,7 +941,7 @@ cdef class CoreProtocol:
         buf.write_int16(0)
 
         buf.write_bytestring(b'client_encoding')
-        buf.write_bytestring("'{}'".format(self.encoding).encode('ascii'))
+        buf.write_bytestring(self.encoding.encode('ascii'))
 
         buf.write_str('user', self.encoding)
         buf.write_str(self.con_params.user, self.encoding)


### PR DESCRIPTION
Fixes: #952

As noted by commenter on https://github.com/MagicStack/asyncpg/issues/952#issuecomment-3677546753, application fails to setup connection because asyncpg wraps the charset with single-quotes, which is unnecessary.

I have tested this fix against
1. RDS Proxy - with and without IAM Auth
2. Direct-to-DB - with and without IAM Auth

Please let me know if there are additional tests necessary. 