### PR TITLE
Build linux/macos arm64/aarch64 wheels on native runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   validate-release-request:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Validate release PR
       uses: edgedb/action-release/validate-pr@master
@@ -44,7 +44,7 @@ jobs:
 
   build-sdist:
     needs: validate-release-request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -73,7 +73,7 @@ jobs:
 
   build-wheels-matrix:
     needs: validate-release-request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
@@ -141,7 +141,7 @@ jobs:
         path: wheelhouse/*.whl
 
   merge-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-sdist, build-wheels]
     steps:
       - name: Merge Artifacts
@@ -152,7 +152,7 @@ jobs:
 
   publish-docs:
     needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -201,7 +201,7 @@ jobs:
 
   publish:
     needs: [build-sdist, build-wheels, publish-docs]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     environment:
       name: pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,20 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - run: pip install cibuildwheel==3.3.0
+      - run: pip install cibuildwheel==3.3.1
       - id: set-matrix
+        env:
+          # skipping pypy for now
+          CIBW_SKIP: >
+            pp*
         run: |
           MATRIX_INCLUDE=$(
             {
-              cibuildwheel --print-build-identifiers --platform linux --archs x86_64,aarch64 | grep cp |  jq -nRc '{"only": inputs, "os": "ubuntu-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64,arm64 | grep cp |  jq -nRc '{"only": inputs, "os": "macos-latest"}' \
-              && cibuildwheel --print-build-identifiers --platform windows --archs x86,AMD64 | grep cp |  jq -nRc '{"only": inputs, "os": "windows-latest"}'
+              cibuildwheel --print-build-identifiers --platform linux --archs x86_64 | jq -nRc '{"only": inputs, "os": "ubuntu-24.04"}' \
+              && cibuildwheel --print-build-identifiers --platform linux --archs aarch64 | jq -nRc '{"only": inputs, "os": "ubuntu-24.04-arm"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --archs x86_64 | jq -nRc '{"only": inputs, "os": "macos-15-intel"}' \
+              && cibuildwheel --print-build-identifiers --platform macos --archs arm64 | jq -nRc '{"only": inputs, "os": "macos-15"}' \
+              && cibuildwheel --print-build-identifiers --platform windows --archs x86,AMD64 | jq -nRc '{"only": inputs, "os": "windows-2025"}'
             } | jq -sc
           )
           echo "include=$MATRIX_INCLUDE" >> $GITHUB_OUTPUT
@@ -123,7 +129,7 @@ jobs:
       if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
 
-    - uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc  # v3.3.0
+    - uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e  # v3.3.1
       with:
         only: ${{ matrix.only }}
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
 
     - name: Build source distribution
       run: |
-        pip install -U setuptools wheel pip
-        python setup.py sdist
+        pip install -U setuptools wheel build
+        python -m build --sdist
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-15, windows-2025]
         loop: [asyncio, uvloop]
         exclude:
           # uvloop does not support windows
           - loop: uvloop
-            os: windows-latest
+            os: windows-2025
+          # github does not provide 3.9 cpython for arm64 runners
+          - python-version: "3.9"
+            os: macos-15
 
     runs-on: ${{ matrix.os }}
 
@@ -54,12 +57,16 @@ jobs:
         version_line_pattern: |
           __version__(?:\s*:\s*typing\.Final)?\s*=\s*(?:['"])([[:PEP440:]])(?:['"])
 
-    - name: Setup PostgreSQL
-      if: "!steps.release.outputs.is_release && matrix.os == 'macos-latest'"
+    - name: Set up PostgreSQL
+      if: "!steps.release.outputs.is_release && startsWith(matrix.os, 'macos')"
       run: |
         POSTGRES_FORMULA="postgresql@18"
         brew install "$POSTGRES_FORMULA"
         echo "$(brew --prefix "$POSTGRES_FORMULA")/bin" >> $GITHUB_PATH
+
+    - name: Set up Kerberos
+      if: "!steps.release.outputs.is_release && startsWith(matrix.os, 'ubuntu')"
+      run: .github/workflows/install-krb5.sh
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: astral-sh/setup-uv@v7
@@ -71,26 +78,20 @@ jobs:
     - name: Install Python Deps
       if: "!steps.release.outputs.is_release"
       run: |
-        [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
         uv pip install -e . --group test
 
     - name: Test
       if: "!steps.release.outputs.is_release"
       env:
-        LOOP_IMPL: ${{ matrix.loop }}
-      run: |
-        if [ "${LOOP_IMPL}" = "uvloop" ]; then
-          env USE_UVLOOP=1 python -m unittest -v tests.suite
-        else
-          python -m unittest -v tests.suite
-        fi
+        USE_UVLOOP: ${{ matrix.loop == 'uvloop' && '1' || '' }}
+      run: python -m unittest -v tests.suite
 
   test-postgres:
     strategy:
       matrix:
         postgres-version: ["9.5", "9.6", "10", "11", "12", "13", "14", "15", "16", "17", "18"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions: {}
 
@@ -122,6 +123,10 @@ jobs:
         echo PGINSTALLATION="/usr/lib/postgresql/${PGVERSION}/bin" \
           >> "${GITHUB_ENV}"
 
+    - name: Set up Kerberos
+      if: "!steps.release.outputs.is_release"
+      run: .github/workflows/install-krb5.sh
+
     - name: Set up Python
       uses: astral-sh/setup-uv@v7
       if: "!steps.release.outputs.is_release"
@@ -131,7 +136,6 @@ jobs:
     - name: Install Python Deps
       if: "!steps.release.outputs.is_release"
       run: |
-        [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
         uv pip install -e . --group test
 
     - name: Test
@@ -146,7 +150,7 @@ jobs:
   regression-tests:
     name: "Regression Tests"
     needs: [test-platforms, test-postgres]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions: {}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+concurrency:  # https://stackoverflow.com/questions/66335225#comment133398800_72408109
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-platforms:
     # NOTE: this matrix is for testing various combinations of Python and OS
@@ -32,9 +36,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    env:
-      PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
     - uses: actions/checkout@v5
@@ -61,18 +62,17 @@ jobs:
         echo "$(brew --prefix "$POSTGRES_FORMULA")/bin" >> $GITHUB_PATH
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v7
       if: "!steps.release.outputs.is_release"
       with:
         python-version: ${{ matrix.python-version }}
+        activate-environment: true
 
     - name: Install Python Deps
       if: "!steps.release.outputs.is_release"
       run: |
         [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
-        python -m pip install -U pip setuptools wheel
-        python -m pip install --group test
-        python -m pip install -e .
+        uv pip install -e . --group test
 
     - name: Test
       if: "!steps.release.outputs.is_release"
@@ -93,9 +93,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions: {}
-
-    env:
-      PIP_DISABLE_PIP_VERSION_CHECK: 1
 
     steps:
     - uses: actions/checkout@v5
@@ -125,19 +122,17 @@ jobs:
         echo PGINSTALLATION="/usr/lib/postgresql/${PGVERSION}/bin" \
           >> "${GITHUB_ENV}"
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+    - name: Set up Python
+      uses: astral-sh/setup-uv@v7
       if: "!steps.release.outputs.is_release"
       with:
-        python-version: "3.x"
+        activate-environment: true
 
     - name: Install Python Deps
       if: "!steps.release.outputs.is_release"
       run: |
         [ "$RUNNER_OS" = "Linux" ] && .github/workflows/install-krb5.sh
-        python -m pip install -U pip setuptools wheel
-        python -m pip install --group test
-        python -m pip install -e .
+        uv pip install -e . --group test
 
     - name: Test
       if: "!steps.release.outputs.is_release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ docs = [
 [build-system]
 requires = [
     "setuptools>=77.0.3",
-    "Cython(>=3.2.1,<4.0.0)"
+    "Cython>=3.2.1,<4.0.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools.command import sdist as setuptools_sdist
 from setuptools.command import build_ext as setuptools_build_ext
 
 
-CYTHON_DEPENDENCY = 'Cython(>=3.2.1,<4.0.0)'
+CYTHON_DEPENDENCY = 'Cython>=3.2.1,<4.0.0'
 
 CFLAGS = ['-O2']
 LDFLAGS = []
@@ -186,7 +186,8 @@ class build_ext(setuptools_build_ext.build_ext):
                         need_cythonize = True
 
         if need_cythonize:
-            import pkg_resources
+            # 'packaging' gets installed by 'wheel'
+            from packaging.requirements import Requirement
 
             # Double check Cython presence in case setup_requires
             # didn't go into effect (most likely because someone
@@ -199,8 +200,8 @@ class build_ext(setuptools_build_ext.build_ext):
                     'please install {} to compile asyncpg from source'.format(
                         CYTHON_DEPENDENCY))
 
-            cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
-            if Cython.__version__ not in cython_dep:
+            cython_dep = Requirement(CYTHON_DEPENDENCY)
+            if Cython.__version__ not in cython_dep.specifier:
                 raise RuntimeError(
                     'asyncpg requires {}, got Cython=={}'.format(
                         CYTHON_DEPENDENCY, Cython.__version__


### PR DESCRIPTION
hi @elprans 👋 

I did the initial implementation of the parallel `release.yml` in https://github.com/MagicStack/asyncpg/pull/954 and I'm providing some maintenance here :)

This PR contains the following commits:
1. switch to linux arm64 native runner ([blog post](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)) and macos x86 native runner ([blog post](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/))
2. fix CI rot related to setuptools deprecating `pkg_resources`
3. various CI speedups
4. fix CI rot related to cpython 3.9 on arm64 macos runners

the runner changes avoid emulation (qemu on linux, rosetta on macos), mainly for speedup (e.g. linux aarch64 wheel build is currently taking 30+ mins vs. 4 mins for x86). i left the `setup-qemu` step in place in case you want to add more wheel architectures for which no native runners exist