### PR TITLE
fix: use ConnectionResetError in TLSUpgradeProto.connection_lost

### DIFF
--- a/asyncpg/connect_utils.py
+++ b/asyncpg/connect_utils.py
@@ -944,7 +944,10 @@ class TLSUpgradeProto(asyncio.Protocol):
     def connection_lost(self, exc: typing.Optional[Exception]) -> None:
         if not self.on_data.done():
             if exc is None:
-                exc = ConnectionError('unexpected connection_lost() call')
+                exc = ConnectionResetError(
+                    'PostgreSQL server at "{host}:{port}" '
+                    'closed the connection during SSL negotiation'.format(
+                        host=self.host, port=self.port))
             self.on_data.set_exception(exc)
 
 


### PR DESCRIPTION
## Summary

Fixes #1310.

`TLSUpgradeProto.connection_lost()` synthesizes a generic `ConnectionError("unexpected connection_lost() call")` when the server closes the connection during SSL negotiation (`exc=None`). This error type is not handled by asyncpg's own `Connection._cancel()`, which only catches `ConnectionResetError`:

```python
# asyncpg/connection.py - Connection._cancel()
except ConnectionResetError as ex:
    # On some systems Postgres will reset the connection
    # after processing the cancellation command.
```

The generic `ConnectionError` falls through to the `except (Exception, ...)` handler and leaks into application code, causing confusing unhandled errors.

### The problem in practice

When `pool_pre_ping` sends a trivial query (`fetchrow(";")`) that gets cancelled (e.g. due to asyncio task cancellation under load), the following cascade occurs:

1. `fetchrow(";")` gets `CancelledError`
2. The `finally` block tries `await tr.rollback()`
3. The rollback triggers `Connection._cancel()` via the cancel side-channel
4. `_cancel()` opens an SSL connection → `TLSUpgradeProto` → server closes during negotiation → `connection_lost(exc=None)`
5. `ConnectionError("unexpected connection_lost() call")` propagates unhandled to application code

### The fix

Use `ConnectionResetError` instead of `ConnectionError`. This is:
- **Semantically correct** — the server reset/closed the connection during SSL negotiation
- **Properly handled** — `Connection._cancel()` already catches `ConnectionResetError` explicitly
- **Consistent** — error message follows the same format as the sibling error in `data_received` (`'PostgreSQL server at "{host}:{port}" rejected SSL upgrade'`)
- **Backward compatible** — `ConnectionResetError` is a subclass of `ConnectionError`, so any existing `except ConnectionError` catches still work

## Test plan

- [ ] Existing test suite passes (no tests reference `"unexpected connection_lost"`)
- [ ] Verify `ConnectionResetError` is caught by `Connection._cancel()`'s existing handler