### PR TITLE
Drop the Cython version check from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -188,27 +188,16 @@ class build_ext(setuptools_build_ext.build_ext):
                         need_cythonize = True
 
         if need_cythonize:
-            import pkg_resources
-
             # Double check Cython presence in case setup_requires
             # didn't go into effect (most likely because someone
             # imported Cython before setup_requires injected the
             # correct egg into sys.path.
             try:
-                import Cython
+                from Cython.Build import cythonize
             except ImportError:
                 raise RuntimeError(
                     'please install {} to compile asyncpg from source'.format(
                         CYTHON_DEPENDENCY))
-
-            cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
-            if Cython.__version__ not in cython_dep:
-                raise RuntimeError(
-                    'asyncpg requires {}, got Cython=={}'.format(
-                        CYTHON_DEPENDENCY, Cython.__version__
-                    ))
-
-            from Cython.Build import cythonize
 
             directives = {
                 'language_level': '3',


### PR DESCRIPTION
This avoids the dependency on the `pkg_resources` module, which has long been deprecated and is no longer shipped with current versions of `setuptools`.

----

The version check could have preserved by replacing

```python
           import pkg_resources
           # …
           cython_dep = pkg_resources.Requirement.parse(CYTHON_DEPENDENCY)
           if Cython.__version__ not in cython_dep:
```

with



```python
           from packaging.requirements import Requirement
           # …
           cython_dep = Requirement(CYTHON_DEPENDENCY)
           if not cython_dep.specifier.contains(Cython.__version__):
```

but then we would need to add a dependency on `packaging` to `build-system.requires` in `pyproject.toml`, and if we can trust `build-system.requires` to give us `packaging`, then we should be able to trust it to give us the correct version of Cython, too!