### PR TITLE
Fix connection pool deadlock

### DIFF
--- a/asyncpg/pool.py
+++ b/asyncpg/pool.py
@@ -199,8 +199,13 @@ class PoolConnectionHolder:
                 'a free connection holder')
 
         if self._con.is_closed():
-            # When closing, pool connections perform the necessary
-            # cleanup, so we don't have to do anything else here.
+            # The connection was closed/aborted, possibly without going
+            # through Connection.close() or Connection.terminate() (e.g.
+            # when the protocol calls abort() on a fatal server error).
+            # In that case, _release_on_close() may never have been called,
+            # so we call _release() here to ensure the holder is returned
+            # to the pool queue.
+            self._release()
             return
 
         self._timeout = None

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1004,6 +1004,19 @@ class TestPool(tb.ConnectedTestCase):
         conn = await pool.acquire(timeout=0.1)
         await pool.release(conn)
 
+    async def test_pool_release_after_protocol_abort(self):
+        pool = await self.create_pool(min_size=1, max_size=1)
+
+        conn = await pool.acquire()
+        conn._con._protocol.abort()
+
+        await pool.release(conn)
+
+        # Check the connection has been released back to the pool
+        conn2 = await pool.acquire(timeout=1.0)
+        await pool.release(conn2)
+        await pool.close()
+
 
 @unittest.skipIf(os.environ.get('PGHOST'), 'unmanaged cluster')
 class TestPoolReconnectWithTargetSessionAttrs(tb.ClusterTestCase):


### PR DESCRIPTION
Fixes an issue where the connection pool can be deadlocked if `abort()` is called which can cause connection cleanup to be skipped. Refer to the referenced issue for a reproducible example

Closes #1307